### PR TITLE
AAI-175 AAI-180 Token Validator & Auth0 Management API integration

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -12,6 +12,12 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    env:
+      AUTH0_DOMAIN: "mock-domain"
+      AUTH0_AUDIENCE: "mock-audience"
+      AUTH0_MANAGEMENT_ID: "mock-id"
+      AUTH0_MANAGEMENT_SECRET: "mock-secret"
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -12,12 +12,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
-    env:
-      AUTH0_DOMAIN: "mock-domain"
-      AUTH0_AUDIENCE: "mock-audience"
-      AUTH0_MANAGEMENT_ID: "mock-id"
-      AUTH0_MANAGEMENT_SECRET: "mock-secret"
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/auth/config.py
+++ b/auth/config.py
@@ -1,0 +1,17 @@
+from functools import lru_cache
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    auth0_domain: str
+    auth0_management_id: str
+    auth0_management_secret: str
+    auth0_audience: str
+    auth0_algorithms: list[str] = ["RS256"]
+
+    model_config = SettingsConfigDict(env_file=".env")
+
+
+@lru_cache()
+def get_settings():
+    return Settings()

--- a/auth/management.py
+++ b/auth/management.py
@@ -1,0 +1,17 @@
+import os
+import requests
+from dotenv import load_dotenv
+
+load_dotenv()
+
+def get_management_token():
+    url = f'https://{os.getenv("AUTH0_DOMAIN")}/oauth/token'
+    payload = {
+        'grant_type': 'client_credentials',
+        'client_id': os.getenv('AUTH0_MANAGEMENT_ID'),
+        'client_secret': os.getenv('AUTH0_MANAGEMENT_SECRET'),
+        'audience': f'https://{os.getenv("AUTH0_DOMAIN")}/api/v2/'
+    }
+    response = requests.post(url, json=payload)
+    response.raise_for_status()
+    return response.json()['access_token']

--- a/auth/management.py
+++ b/auth/management.py
@@ -1,16 +1,16 @@
 import os
 import requests
-from dotenv import load_dotenv
+from .config import get_settings
 
-load_dotenv()
 
 def get_management_token():
+    settings = get_settings()
     url = f'https://{os.getenv("AUTH0_DOMAIN")}/oauth/token'
     payload = {
         'grant_type': 'client_credentials',
-        'client_id': os.getenv('AUTH0_MANAGEMENT_ID'),
-        'client_secret': os.getenv('AUTH0_MANAGEMENT_SECRET'),
-        'audience': f'https://{os.getenv("AUTH0_DOMAIN")}/api/v2/'
+        'client_id': settings.auth0_management_id,
+        'client_secret': settings.auth0_management_secret,
+        'audience': f'https://{settings.auth0_domain}/api/v2/'
     }
     response = requests.post(url, json=payload)
     response.raise_for_status()

--- a/auth/management.py
+++ b/auth/management.py
@@ -1,4 +1,4 @@
-import requests
+import httpx
 
 from .config import get_settings
 
@@ -12,6 +12,6 @@ def get_management_token():
         'client_secret': settings.auth0_management_secret,
         'audience': f'https://{settings.auth0_domain}/api/v2/'
     }
-    response = requests.post(url, json=payload)
+    response = httpx.post(url, json=payload)
     response.raise_for_status()
     return response.json()['access_token']

--- a/auth/management.py
+++ b/auth/management.py
@@ -5,7 +5,7 @@ from .config import get_settings
 
 def get_management_token():
     settings = get_settings()
-    url = f'https://{os.getenv("AUTH0_DOMAIN")}/oauth/token'
+    url = f'https://{settings.auth0_domain}/oauth/token'
     payload = {
         'grant_type': 'client_credentials',
         'client_id': settings.auth0_management_id,

--- a/auth/management.py
+++ b/auth/management.py
@@ -1,5 +1,5 @@
-import os
 import requests
+
 from .config import get_settings
 
 

--- a/auth/validator.py
+++ b/auth/validator.py
@@ -2,51 +2,51 @@ from typing import Dict
 
 import httpx
 from fastapi import HTTPException
-from jose import jwt
+from jose import jwt, jwk
 from jose.exceptions import JWTError
 
 from auth.config import get_settings
 
 
+def get_rsa_key(token: str) -> jwk.RSAKey | None:
+    settings = get_settings()
+    jwks_url = f"https://{settings.auth0_domain}/.well-known/jwks.json"
+    response = httpx.get(jwks_url)
+    jwks = response.json()
+    unverified_header = jwt.get_unverified_header(token)
+
+    for key in jwks["keys"]:
+        if key["kid"] == unverified_header["kid"]:
+            return jwk.RSAKey(**key)
+    return None
+
+
 def verify_jwt(token: str) -> Dict:
     settings = get_settings()
     try:
-        jwks_url = f"https://{settings.auth0_domain}/.well-known/jwks.json"
-        response = httpx.get(jwks_url)
-        jwks = response.json()
+        rsa_key = get_rsa_key(token)
+    except JWTError as e:
+        raise HTTPException(status_code=401, detail=f"Invalid token: {e}")
+    if rsa_key is None:
+        raise HTTPException(status_code=401, detail="Couldn't find a matching signing key.")
 
-        unverified_header = jwt.get_unverified_header(token)
-        rsa_key = {}
-        for key in jwks["keys"]:
-            if key["kid"] == unverified_header["kid"]:
-                rsa_key = {
-                    "kty": key["kty"],
-                    "kid": key["kid"],
-                    "use": key["use"],
-                    "n": key["n"],
-                    "e": key["e"]
-                }
-
-        if rsa_key:
-            payload = jwt.decode(
-                token,
-                rsa_key,
-                algorithms=settings.auth0_algorithms,
-                audience=settings.auth0_audience,
-                issuer=f"https://{settings.auth0_domain}/"
-            )
-
-            roles_claim = "biocommons.org.au/roles"
-            if roles_claim not in payload:
-                raise HTTPException(status_code=403, detail=f"Missing required claim: {roles_claim}")
-
-            roles = payload[roles_claim]
-            if not isinstance(roles, list) or not any("admin" in role.lower() for role in roles):
-                raise HTTPException(status_code=403, detail=f"Access denied: Insufficient permissions")
-
-            return payload
-
+    try:
+        payload = jwt.decode(
+            token,
+            rsa_key,
+            algorithms=settings.auth0_algorithms,
+            audience=settings.auth0_audience,
+            issuer=f"https://{settings.auth0_domain}/"
+        )
     except JWTError as e:
         raise HTTPException(status_code=401, detail=f"Invalid token: {e}")
 
-    raise HTTPException(status_code=401, detail="Unable to verify token")
+    roles_claim = "biocommons.org.au/roles"
+    if roles_claim not in payload:
+        raise HTTPException(status_code=403, detail=f"Missing required claim: {roles_claim}")
+
+    roles = payload[roles_claim]
+    if not isinstance(roles, list) or not any("admin" in role.lower() for role in roles):
+        raise HTTPException(status_code=403, detail=f"Access denied: Insufficient permissions")
+
+    return payload

--- a/auth/validator.py
+++ b/auth/validator.py
@@ -5,12 +5,13 @@ from fastapi import HTTPException
 from typing import Dict
 import httpx
 import os
+import json
 
 load_dotenv()
 
 AUTH0_DOMAIN = os.getenv("AUTH0_DOMAIN")
 API_AUDIENCE = os.getenv("AUTH0_AUDIENCE")
-ALGORITHMS = os.getenv("AUTH0_ALGORITHMS")
+ALGORITHMS = json.loads(os.getenv("AUTH0_ALGORITHMS", '["RS256"]'))
 
 def verify_jwt(token: str) -> Dict:
     try:

--- a/auth/validator.py
+++ b/auth/validator.py
@@ -18,7 +18,7 @@ def get_rsa_key(token: str) -> jwk.RSAKey | None:
 
     for key in jwks["keys"]:
         if key["kid"] == unverified_header["kid"]:
-            return jwk.RSAKey(**key)
+            return jwk.construct(key)
     return None
 
 

--- a/auth/validator.py
+++ b/auth/validator.py
@@ -39,6 +39,15 @@ def verify_jwt(token: str) -> Dict:
                 audience=API_AUDIENCE,
                 issuer=f"https://{AUTH0_DOMAIN}/"
             )
+
+            roles_claim = "biocommons.org.au/roles"
+            if roles_claim not in payload:
+                raise HTTPException(status_code=403, detail=f"Missing required claim: {roles_claim}")
+
+            roles = payload[roles_claim]
+            if not isinstance(roles, list) or not any("admin" in role.lower() for role in roles):
+                raise HTTPException(status_code=403, detail=f"Access denied: Insufficient permissions")
+
             return payload
 
     except JWTError as e:

--- a/auth/validator.py
+++ b/auth/validator.py
@@ -4,8 +4,10 @@ import httpx
 from fastapi import HTTPException
 from jose import jwt, jwk
 from jose.exceptions import JWTError
+from pydantic import ValidationError
 
 from auth.config import get_settings
+from schemas.tokens import AccessTokenPayload
 
 
 def get_rsa_key(token: str) -> jwk.RSAKey | None:
@@ -21,7 +23,7 @@ def get_rsa_key(token: str) -> jwk.RSAKey | None:
     return None
 
 
-def verify_jwt(token: str) -> Dict:
+def verify_jwt(token: str) -> AccessTokenPayload:
     settings = get_settings()
     try:
         rsa_key = get_rsa_key(token)
@@ -49,4 +51,4 @@ def verify_jwt(token: str) -> Dict:
     if not isinstance(roles, list) or not any("admin" in role.lower() for role in roles):
         raise HTTPException(status_code=403, detail=f"Access denied: Insufficient permissions")
 
-    return payload
+    return AccessTokenPayload(**payload)

--- a/auth/validator.py
+++ b/auth/validator.py
@@ -1,0 +1,46 @@
+from dotenv import load_dotenv
+from jose import jwt
+from jose.exceptions import JWTError
+from fastapi import HTTPException
+from typing import Dict
+import httpx
+import os
+
+load_dotenv()
+
+AUTH0_DOMAIN = os.getenv("AUTH0_DOMAIN")
+API_AUDIENCE = os.getenv("AUTH0_AUDIENCE")
+ALGORITHMS = os.getenv("AUTH0_ALGORITHMS")
+
+def verify_jwt(token: str) -> Dict:
+    try:
+        jwks_url = f"https://{AUTH0_DOMAIN}/.well-known/jwks.json"
+        response = httpx.get(jwks_url)
+        jwks = response.json()
+
+        unverified_header = jwt.get_unverified_header(token)
+        rsa_key = {}
+        for key in jwks["keys"]:
+            if key["kid"] == unverified_header["kid"]:
+                rsa_key = {
+                    "kty": key["kty"],
+                    "kid": key["kid"],
+                    "use": key["use"],
+                    "n": key["n"],
+                    "e": key["e"]
+                }
+
+        if rsa_key:
+            payload = jwt.decode(
+                token,
+                rsa_key,
+                algorithms=ALGORITHMS,
+                audience=API_AUDIENCE,
+                issuer=f"https://{AUTH0_DOMAIN}/"
+            )
+            return payload
+
+    except JWTError as e:
+        raise HTTPException(status_code=401, detail=f"Invalid token: {e}")
+
+    raise HTTPException(status_code=401, detail="Unable to verify token")

--- a/auth/validator.py
+++ b/auth/validator.py
@@ -4,7 +4,6 @@ import httpx
 from fastapi import HTTPException
 from jose import jwt, jwk
 from jose.exceptions import JWTError
-from pydantic import ValidationError
 
 from auth.config import get_settings
 from schemas.tokens import AccessTokenPayload

--- a/auth/validator.py
+++ b/auth/validator.py
@@ -1,21 +1,16 @@
-from dotenv import load_dotenv
 from jose import jwt
 from jose.exceptions import JWTError
 from fastapi import HTTPException
 from typing import Dict
 import httpx
-import os
-import json
 
-load_dotenv()
+from auth.config import get_settings
 
-AUTH0_DOMAIN = os.getenv("AUTH0_DOMAIN")
-API_AUDIENCE = os.getenv("AUTH0_AUDIENCE")
-ALGORITHMS = json.loads(os.getenv("AUTH0_ALGORITHMS", '["RS256"]'))
 
 def verify_jwt(token: str) -> Dict:
+    settings = get_settings()
     try:
-        jwks_url = f"https://{AUTH0_DOMAIN}/.well-known/jwks.json"
+        jwks_url = f"https://{settings.auth0_domain}/.well-known/jwks.json"
         response = httpx.get(jwks_url)
         jwks = response.json()
 
@@ -35,9 +30,9 @@ def verify_jwt(token: str) -> Dict:
             payload = jwt.decode(
                 token,
                 rsa_key,
-                algorithms=ALGORITHMS,
-                audience=API_AUDIENCE,
-                issuer=f"https://{AUTH0_DOMAIN}/"
+                algorithms=settings.auth0_algorithms,
+                audience=settings.auth0_audience,
+                issuer=f"https://{settings.auth0_domain}/"
             )
 
             roles_claim = "biocommons.org.au/roles"

--- a/auth/validator.py
+++ b/auth/validator.py
@@ -1,8 +1,9 @@
+from typing import Dict
+
+import httpx
+from fastapi import HTTPException
 from jose import jwt
 from jose.exceptions import JWTError
-from fastapi import HTTPException
-from typing import Dict
-import httpx
 
 from auth.config import get_settings
 

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 from fastapi import Depends, FastAPI
 from fastapi.security import OAuth2PasswordBearer
+from auth.management import get_management_token
 from auth.validator import verify_jwt
 
 app = FastAPI()
@@ -14,4 +15,4 @@ def public_route():
 
 @app.get("/private")
 def private_route(user=Depends(get_current_user)):
-    return {"message": "Private route", "user_claims": user}
+    return {"message": "Private route", "user_claims": user, "management_token": get_management_token()}

--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-from fastapi import Depends, FastAPI
+from fastapi import Depends, FastAPI, HTTPException
 from fastapi.security import OAuth2PasswordBearer
 from auth.management import get_management_token
 from auth.validator import verify_jwt

--- a/main.py
+++ b/main.py
@@ -1,7 +1,17 @@
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI
+from fastapi.security import OAuth2PasswordBearer
+from auth.validator import verify_jwt
 
 app = FastAPI()
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
+
+def get_current_user(token: str = Depends(oauth2_scheme)):
+    return verify_jwt(token)
 
 @app.get("/")
-def read_root():
-    return {"message": "FastAPI with uv"}
+def public_route():
+    return {"message": "Public route"}
+
+@app.get("/private")
+def private_route(user=Depends(get_current_user)):
+    return {"message": "Private route", "user_claims": user}

--- a/main.py
+++ b/main.py
@@ -1,10 +1,13 @@
-from fastapi import Depends, FastAPI, HTTPException
+from fastapi import Depends, FastAPI
 from fastapi.security import OAuth2PasswordBearer
+
 from auth.management import get_management_token
 from auth.validator import verify_jwt
 
+
 app = FastAPI()
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
+
 
 def get_current_user(token: str = Depends(oauth2_scheme)):
     return verify_jwt(token)

--- a/main.py
+++ b/main.py
@@ -3,14 +3,15 @@ from fastapi.security import OAuth2PasswordBearer
 
 from auth.management import get_management_token
 from auth.validator import verify_jwt
-
+from schemas.user import User
 
 app = FastAPI()
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
 
 
-def get_current_user(token: str = Depends(oauth2_scheme)):
-    return verify_jwt(token)
+def get_current_user(token: str = Depends(oauth2_scheme)) -> User:
+    access_token = verify_jwt(token)
+    return User(access_token=access_token)
 
 @app.get("/")
 def public_route():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,8 @@ requires-python = ">=3.13"
 dependencies = [
     "fastapi[standard]>=0.115.12",
     "httpx>=0.28.1",
+    "python-jose>=3.4.0",
+    "requests>=2.32.3",
 ]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ dependencies = [
     "httpx>=0.28.1",
     "pydantic-settings>=2.8.1",
     "python-jose>=3.4.0",
-    "requests>=2.32.3",
 ]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ requires-python = ">=3.13"
 dependencies = [
     "fastapi[standard]>=0.115.12",
     "httpx>=0.28.1",
+    "pydantic-settings>=2.8.1",
     "python-jose>=3.4.0",
     "requests>=2.32.3",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ testpaths=["tests"]
 
 [dependency-groups]
 dev = [
+    "polyfactory>=2.21.0",
     "pytest>=8.3.5",
     "pytest-mock>=3.14.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,4 +18,5 @@ testpaths=["tests"]
 [dependency-groups]
 dev = [
     "pytest>=8.3.5",
+    "pytest-mock>=3.14.0",
 ]

--- a/schemas/group.py
+++ b/schemas/group.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel
 
+
 class Group(BaseModel):
     name: str
     id: str

--- a/schemas/service.py
+++ b/schemas/service.py
@@ -2,6 +2,7 @@ from pydantic import BaseModel, Field
 from typing import Literal
 from datetime import datetime
 
+
 class Resource(BaseModel):
     name: str
     status: Literal["approved", "revoked", "pending"]

--- a/schemas/tokens.py
+++ b/schemas/tokens.py
@@ -1,0 +1,20 @@
+from pydantic import BaseModel, Field
+from typing import Optional
+
+
+class AccessTokenPayload(BaseModel):
+    """
+    Schema for the access token payload.
+    """
+    biocommons_roles: list[str] = Field(
+        alias="biocommons.org.au/roles",
+        description="BioCommons-specific roles assigned to the user"
+    )
+    email: Optional[str] = Field(None, description="Email address")
+    iss: str = Field(description="Issuer identifier")
+    sub: str = Field(description="Subject identifier")
+    aud: list[str] = Field(description="Audience(s) that this token is intended for")
+    exp: int = Field(description="Expiration time (as Unix timestamp)")
+    iat: int = Field(description="Issued at time (as Unix timestamp)")
+    azp: Optional[str] = Field(None, description="Authorized party")
+    permissions: list[str] = Field(description="Permissions granted to the user")

--- a/schemas/user.py
+++ b/schemas/user.py
@@ -1,0 +1,23 @@
+from pydantic import BaseModel
+from .tokens import AccessTokenPayload
+
+
+class User(BaseModel):
+    """
+    Define our user model so we can implement any required
+    permissions checks here, instead of doing individual
+    checks in different places.
+    """
+    access_token: AccessTokenPayload
+
+    def is_admin(self) -> bool:
+        """
+        Checks if the user has an admin role.
+        """
+        # TODO: Need to finalize exactly what roles make
+        #   a user an admin
+        for role in self.access_token.biocommons_roles:
+            if "admin" in role.lower():
+                return True
+        return False
+

--- a/tests/datagen.py
+++ b/tests/datagen.py
@@ -1,0 +1,12 @@
+from polyfactory.factories.pydantic_factory import ModelFactory
+
+from schemas.tokens import AccessTokenPayload
+from schemas.user import User
+
+
+class AccessTokenPayloadFactory(ModelFactory[AccessTokenPayload]):
+    ...
+
+
+class UserFactory(ModelFactory[User]):
+    ...

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -42,13 +42,6 @@ def test_private_missing_token():
     assert response.json() == {"detail": "Not authenticated"}
 
 def test_private_invalid_token(mocker):
-    mocker.patch("auth.config.get_settings", return_value=Settings(
-        auth0_domain="mock-domain",
-        auth0_audience="mock-audience",
-        auth0_management_id="mock-id",
-        auth0_management_secret="mock-secret",
-        auth0_algorithms=["RS256"]
-    ))
     mocker.patch("auth.validator.verify_jwt", side_effect=Exception("Invalid token: Error decoding token headers."))
     headers = {"Authorization": "Bearer invalid_token"}
     response = client.get("/private", headers=headers)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,7 +3,7 @@ from main import app
 
 client = TestClient(app)
 
-def test_root():
+def test_public():
     response = client.get("/")
     assert response.status_code == 200
-    assert response.json() == {"message": "FastAPI with uv"}
+    assert response.json() == {"message": "Public route"}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,28 +1,37 @@
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
-from main import app
+
 from auth.config import Settings
+from main import app
 
 client = TestClient(app)
+
 
 def test_public():
     response = client.get("/")
     assert response.status_code == 200
     assert response.json() == {"message": "Public route"}
 
-def test_private_valid_token(mocker):
-    mocker.patch("auth.config.get_settings", return_value=Settings(
-        auth0_domain="mock-domain",
-        auth0_audience="mock-audience",
-        auth0_management_id="mock-id",
-        auth0_management_secret="mock-secret",
-        auth0_algorithms=["RS256"]
-    ))
 
-    mocker.patch("main.verify_jwt", return_value={
-        "sub": "auth0|123456789",
-        "biocommons.org.au/roles": ["acdc/indexd_admin"]
-    })
+def test_private_valid_token(mocker):
+    mocker.patch(
+        "auth.config.get_settings",
+        return_value=Settings(
+            auth0_domain="mock-domain",
+            auth0_audience="mock-audience",
+            auth0_management_id="mock-id",
+            auth0_management_secret="mock-secret",
+            auth0_algorithms=["RS256"],
+        ),
+    )
+
+    mocker.patch(
+        "main.verify_jwt",
+        return_value={
+            "sub": "auth0|123456789",
+            "biocommons.org.au/roles": ["acdc/indexd_admin"],
+        },
+    )
     mocker.patch("main.get_management_token", return_value="mock_management_token")
     headers = {"Authorization": "Bearer valid_token"}
     response = client.get("/private", headers=headers)
@@ -31,30 +40,45 @@ def test_private_valid_token(mocker):
         "message": "Private route",
         "user_claims": {
             "sub": "auth0|123456789",
-            "biocommons.org.au/roles": ["acdc/indexd_admin"]
+            "biocommons.org.au/roles": ["acdc/indexd_admin"],
         },
-        "management_token": "mock_management_token"
+        "management_token": "mock_management_token",
     }
+
 
 def test_private_missing_token():
     response = client.get("/private")
     assert response.status_code == 401
     assert response.json() == {"detail": "Not authenticated"}
 
+
 def test_private_invalid_token(mocker):
-    mocker.patch("httpx.get", return_value=mocker.Mock(json=lambda: {"keys": []}))
-    mocker.patch("auth.validator.verify_jwt", side_effect=Exception("Invalid token: Error decoding token headers."))
+    mocker.patch(
+        "httpx.get", return_value=mocker.Mock(json=lambda: {"keys": []})
+    )
+    mocker.patch(
+        "auth.validator.verify_jwt",
+        side_effect=Exception("Invalid token: Error decoding token headers."),
+    )
 
     headers = {"Authorization": "Bearer invalid_token"}
     response = client.get("/private", headers=headers)
     assert response.status_code == 401
-    assert response.json() == {"detail": "Invalid token: Error decoding token headers."}
+    assert response.json() == {
+        "detail": "Invalid token: Error decoding token headers."
+    }
+
 
 def test_private_insufficient_permissions(mocker):
-    mocker.patch("main.verify_jwt", side_effect=HTTPException(
-        status_code=403, detail="Access denied: Insufficient permissions"
-    ))
+    mocker.patch(
+        "main.verify_jwt",
+        side_effect=HTTPException(
+            status_code=403, detail="Access denied: Insufficient permissions"
+        ),
+    )
     headers = {"Authorization": "Bearer insufficient_permissions_token"}
     response = client.get("/private", headers=headers)
     assert response.status_code == 403
-    assert response.json() == {"detail": "Access denied: Insufficient permissions"}
+    assert response.json() == {
+        "detail": "Access denied: Insufficient permissions"
+    }

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,3 +1,4 @@
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 from main import app
 
@@ -7,3 +8,42 @@ def test_public():
     response = client.get("/")
     assert response.status_code == 200
     assert response.json() == {"message": "Public route"}
+
+def test_private_valid_token(mocker):
+    mocker.patch("main.verify_jwt", return_value={
+        "sub": "auth0|123456789",
+        "biocommons.org.au/roles": ["acdc/indexd_admin"]
+    })
+    mocker.patch("main.get_management_token", return_value="mock_management_token")
+    headers = {"Authorization": "Bearer valid_token"}
+    response = client.get("/private", headers=headers)
+    assert response.status_code == 200
+    assert response.json() == {
+        "message": "Private route",
+        "user_claims": {
+            "sub": "auth0|123456789",
+            "biocommons.org.au/roles": ["acdc/indexd_admin"]
+        },
+        "management_token": "mock_management_token"
+    }
+
+def test_private_missing_token():
+    response = client.get("/private")
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Not authenticated"}
+
+def test_private_invalid_token(mocker):
+    mocker.patch("auth.validator.verify_jwt", side_effect=Exception("Invalid token: Error decoding token headers."))
+    headers = {"Authorization": "Bearer invalid_token"}
+    response = client.get("/private", headers=headers)
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Invalid token: Error decoding token headers."}
+
+def test_private_insufficient_permissions(mocker):
+    mocker.patch("main.verify_jwt", side_effect=HTTPException(
+        status_code=403, detail="Access denied: Insufficient permissions"
+    ))
+    headers = {"Authorization": "Bearer insufficient_permissions_token"}
+    response = client.get("/private", headers=headers)
+    assert response.status_code == 403
+    assert response.json() == {"detail": "Access denied: Insufficient permissions"}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -42,7 +42,9 @@ def test_private_missing_token():
     assert response.json() == {"detail": "Not authenticated"}
 
 def test_private_invalid_token(mocker):
+    mocker.patch("httpx.get", return_value=mocker.Mock(json=lambda: {"keys": []}))
     mocker.patch("auth.validator.verify_jwt", side_effect=Exception("Invalid token: Error decoding token headers."))
+
     headers = {"Authorization": "Bearer invalid_token"}
     response = client.get("/private", headers=headers)
     assert response.status_code == 401

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -10,6 +10,14 @@ def test_public():
     assert response.json() == {"message": "Public route"}
 
 def test_private_valid_token(mocker):
+    mocker.patch("auth.config.get_settings", return_value={
+        "auth0_domain": "mock-domain",
+        "auth0_audience": "mock-audience",
+        "auth0_management_id": "mock-id",
+        "auth0_management_secret": "mock-secret",
+        "auth0_algorithms": ["RS256"]
+    })
+
     mocker.patch("main.verify_jwt", return_value={
         "sub": "auth0|123456789",
         "biocommons.org.au/roles": ["acdc/indexd_admin"]
@@ -33,6 +41,14 @@ def test_private_missing_token():
     assert response.json() == {"detail": "Not authenticated"}
 
 def test_private_invalid_token(mocker):
+    mocker.patch("auth.config.get_settings", return_value={
+        "auth0_domain": "mock-domain",
+        "auth0_audience": "mock-audience",
+        "auth0_management_id": "mock-id",
+        "auth0_management_secret": "mock-secret",
+        "auth0_algorithms": ["RS256"]
+    })
+
     mocker.patch("auth.validator.verify_jwt", side_effect=Exception("Invalid token: Error decoding token headers."))
     headers = {"Authorization": "Bearer invalid_token"}
     response = client.get("/private", headers=headers)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,7 @@
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
 from main import app
+from auth.config import Settings
 
 client = TestClient(app)
 
@@ -10,13 +11,13 @@ def test_public():
     assert response.json() == {"message": "Public route"}
 
 def test_private_valid_token(mocker):
-    mocker.patch("auth.config.get_settings", return_value={
-        "auth0_domain": "mock-domain",
-        "auth0_audience": "mock-audience",
-        "auth0_management_id": "mock-id",
-        "auth0_management_secret": "mock-secret",
-        "auth0_algorithms": ["RS256"]
-    })
+    mocker.patch("auth.config.get_settings", return_value=Settings(
+        auth0_domain="mock-domain",
+        auth0_audience="mock-audience",
+        auth0_management_id="mock-id",
+        auth0_management_secret="mock-secret",
+        auth0_algorithms=["RS256"]
+    ))
 
     mocker.patch("main.verify_jwt", return_value={
         "sub": "auth0|123456789",
@@ -41,13 +42,13 @@ def test_private_missing_token():
     assert response.json() == {"detail": "Not authenticated"}
 
 def test_private_invalid_token(mocker):
-    mocker.patch("auth.config.get_settings", return_value={
-        "auth0_domain": "mock-domain",
-        "auth0_audience": "mock-audience",
-        "auth0_management_id": "mock-id",
-        "auth0_management_secret": "mock-secret",
-        "auth0_algorithms": ["RS256"]
-    })
+    mocker.patch("auth.config.get_settings", return_value=Settings(
+        auth0_domain="mock-domain",
+        auth0_audience="mock-audience",
+        auth0_management_id="mock-id",
+        auth0_management_secret="mock-secret",
+        auth0_algorithms=["RS256"]
+    ))
 
     mocker.patch("auth.validator.verify_jwt", side_effect=Exception("Invalid token: Error decoding token headers."))
     headers = {"Authorization": "Bearer invalid_token"}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -49,7 +49,6 @@ def test_private_invalid_token(mocker):
         auth0_management_secret="mock-secret",
         auth0_algorithms=["RS256"]
     ))
-
     mocker.patch("auth.validator.verify_jwt", side_effect=Exception("Invalid token: Error decoding token headers."))
     headers = {"Authorization": "Bearer invalid_token"}
     response = client.get("/private", headers=headers)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,5 @@
-from fastapi.testclient import TestClient
 import pytest
+from fastapi.testclient import TestClient
 
 from auth.config import Settings
 from main import app

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,6 +4,7 @@ from fastapi.testclient import TestClient
 from auth.config import Settings
 from main import app
 
+
 client = TestClient(app)
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -9,6 +9,8 @@ source = { virtual = "." }
 dependencies = [
     { name = "fastapi", extra = ["standard"] },
     { name = "httpx" },
+    { name = "python-jose" },
+    { name = "requests" },
 ]
 
 [package.dev-dependencies]
@@ -20,6 +22,8 @@ dev = [
 requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.12" },
     { name = "httpx", specifier = ">=0.28.1" },
+    { name = "python-jose", specifier = ">=3.4.0" },
+    { name = "requests", specifier = ">=2.32.3" },
 ]
 
 [package.metadata.requires-dev]
@@ -57,6 +61,28 @@ wheels = [
 ]
 
 [[package]]
+name = "charset-normalizer"
+version = "3.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/16/b0/572805e227f01586461c80e0fd25d65a2115599cc9dad142fee4b747c357/charset_normalizer-3.4.1.tar.gz", hash = "sha256:44251f18cd68a75b56585dd00dae26183e102cd5e0f9f1466e6df5da2ed64ea3", size = 123188 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/94/ce8e6f63d18049672c76d07d119304e1e2d7c6098f0841b51c666e9f44a0/charset_normalizer-3.4.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:aabfa34badd18f1da5ec1bc2715cadc8dca465868a4e73a0173466b688f29dda", size = 195698 },
+    { url = "https://files.pythonhosted.org/packages/24/2e/dfdd9770664aae179a96561cc6952ff08f9a8cd09a908f259a9dfa063568/charset_normalizer-3.4.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:22e14b5d70560b8dd51ec22863f370d1e595ac3d024cb8ad7d308b4cd95f8313", size = 140162 },
+    { url = "https://files.pythonhosted.org/packages/24/4e/f646b9093cff8fc86f2d60af2de4dc17c759de9d554f130b140ea4738ca6/charset_normalizer-3.4.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8436c508b408b82d87dc5f62496973a1805cd46727c34440b0d29d8a2f50a6c9", size = 150263 },
+    { url = "https://files.pythonhosted.org/packages/5e/67/2937f8d548c3ef6e2f9aab0f6e21001056f692d43282b165e7c56023e6dd/charset_normalizer-3.4.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2d074908e1aecee37a7635990b2c6d504cd4766c7bc9fc86d63f9c09af3fa11b", size = 142966 },
+    { url = "https://files.pythonhosted.org/packages/52/ed/b7f4f07de100bdb95c1756d3a4d17b90c1a3c53715c1a476f8738058e0fa/charset_normalizer-3.4.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:955f8851919303c92343d2f66165294848d57e9bba6cf6e3625485a70a038d11", size = 144992 },
+    { url = "https://files.pythonhosted.org/packages/96/2c/d49710a6dbcd3776265f4c923bb73ebe83933dfbaa841c5da850fe0fd20b/charset_normalizer-3.4.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:44ecbf16649486d4aebafeaa7ec4c9fed8b88101f4dd612dcaf65d5e815f837f", size = 147162 },
+    { url = "https://files.pythonhosted.org/packages/b4/41/35ff1f9a6bd380303dea55e44c4933b4cc3c4850988927d4082ada230273/charset_normalizer-3.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0924e81d3d5e70f8126529951dac65c1010cdf117bb75eb02dd12339b57749dd", size = 140972 },
+    { url = "https://files.pythonhosted.org/packages/fb/43/c6a0b685fe6910d08ba971f62cd9c3e862a85770395ba5d9cad4fede33ab/charset_normalizer-3.4.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:2967f74ad52c3b98de4c3b32e1a44e32975e008a9cd2a8cc8966d6a5218c5cb2", size = 149095 },
+    { url = "https://files.pythonhosted.org/packages/4c/ff/a9a504662452e2d2878512115638966e75633519ec11f25fca3d2049a94a/charset_normalizer-3.4.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:c75cb2a3e389853835e84a2d8fb2b81a10645b503eca9bcb98df6b5a43eb8886", size = 152668 },
+    { url = "https://files.pythonhosted.org/packages/6c/71/189996b6d9a4b932564701628af5cee6716733e9165af1d5e1b285c530ed/charset_normalizer-3.4.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:09b26ae6b1abf0d27570633b2b078a2a20419c99d66fb2823173d73f188ce601", size = 150073 },
+    { url = "https://files.pythonhosted.org/packages/e4/93/946a86ce20790e11312c87c75ba68d5f6ad2208cfb52b2d6a2c32840d922/charset_normalizer-3.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:fa88b843d6e211393a37219e6a1c1df99d35e8fd90446f1118f4216e307e48cd", size = 145732 },
+    { url = "https://files.pythonhosted.org/packages/cd/e5/131d2fb1b0dddafc37be4f3a2fa79aa4c037368be9423061dccadfd90091/charset_normalizer-3.4.1-cp313-cp313-win32.whl", hash = "sha256:eb8178fe3dba6450a3e024e95ac49ed3400e506fd4e9e5c32d30adda88cbd407", size = 95391 },
+    { url = "https://files.pythonhosted.org/packages/27/f2/4f9a69cc7712b9b5ad8fdb87039fd89abba997ad5cbe690d1835d40405b0/charset_normalizer-3.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:b1ac5992a838106edb89654e0aebfc24f5848ae2547d22c2c3f66454daa11971", size = 102702 },
+    { url = "https://files.pythonhosted.org/packages/0e/f6/65ecc6878a89bb1c23a086ea335ad4bf21a588990c3f535a227b9eea9108/charset_normalizer-3.4.1-py3-none-any.whl", hash = "sha256:d98b1668f06378c6dbefec3b92299716b931cd4e6061f3c875a71ced1780ab85", size = 49767 },
+]
+
+[[package]]
 name = "click"
 version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
@@ -84,6 +110,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b5/4a/263763cb2ba3816dd94b08ad3a33d5fdae34ecb856678773cc40a3605829/dnspython-2.7.0.tar.gz", hash = "sha256:ce9c432eda0dc91cf618a5cedf1a4e142651196bbcd2c80e89ed5a907e5cfaf1", size = 345197 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/68/1b/e0a87d256e40e8c888847551b20a017a6b98139178505dc7ffb96f04e954/dnspython-2.7.0-py3-none-any.whl", hash = "sha256:b4c34b7d10b51bcc3a5071e7b8dee77939f1e878477eeecc965e9835f63c6c86", size = 313632 },
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.19.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/1f/924e3caae75f471eae4b26bd13b698f6af2c44279f67af317439c2f4c46a/ecdsa-0.19.1.tar.gz", hash = "sha256:478cba7b62555866fcb3bb3fe985e06decbdb68ef55713c4e5ab98c57d508e61", size = 201793 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/a3/460c57f094a4a165c84a1341c373b0a4f5ec6ac244b998d5021aade89b77/ecdsa-0.19.1-py2.py3-none-any.whl", hash = "sha256:30638e27cf77b7e15c4c4cc1973720149e1033827cfd00661ca5c8cc0cdb24c3", size = 150607 },
 ]
 
 [[package]]
@@ -292,6 +330,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pyasn1"
+version = "0.4.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/db/fffec68299e6d7bad3d504147f9094830b704527a7fc098b721d38cc7fa7/pyasn1-0.4.8.tar.gz", hash = "sha256:aef77c9fb94a3ac588e87841208bdec464471d9871bd5050a287cc9a475cd0ba", size = 146820 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/1e/a94a8d635fa3ce4cfc7f506003548d0a2447ae76fd5ca53932970fe3053f/pyasn1-0.4.8-py2.py3-none-any.whl", hash = "sha256:39c7e2ec30515947ff4e87fb6f456dfc6e84857d34be479c9d4a4ba4bf46aa5d", size = 77145 },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.11.3"
 source = { registry = "https://pypi.org/simple" }
@@ -368,6 +415,20 @@ wheels = [
 ]
 
 [[package]]
+name = "python-jose"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ecdsa" },
+    { name = "pyasn1" },
+    { name = "rsa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/a0/c49687cf40cb6128ea4e0559855aff92cd5ebd1a60a31c08526818c0e51e/python-jose-3.4.0.tar.gz", hash = "sha256:9a9a40f418ced8ecaf7e3b28d69887ceaa76adad3bcaa6dae0d9e596fec1d680", size = 92145 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/b0/2586ea6b6fd57a994ece0b56418cbe93fff0efb85e2c9eb6b0caf24a4e37/python_jose-3.4.0-py2.py3-none-any.whl", hash = "sha256:9c9f616819652d109bd889ecd1e15e9a162b9b94d682534c9c2146092945b78f", size = 34616 },
+]
+
+[[package]]
 name = "python-multipart"
 version = "0.0.20"
 source = { registry = "https://pypi.org/simple" }
@@ -391,6 +452,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fe/0f/25911a9f080464c59fab9027482f822b86bf0608957a5fcc6eaac85aa515/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652", size = 751597 },
     { url = "https://files.pythonhosted.org/packages/14/0d/e2c3b43bbce3cf6bd97c840b46088a3031085179e596d4929729d8d68270/PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183", size = 140527 },
     { url = "https://files.pythonhosted.org/packages/fa/de/02b54f42487e3d3c6efb3f89428677074ca7bf43aae402517bc7cca949f3/PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563", size = 156446 },
+]
+
+[[package]]
+name = "requests"
+version = "2.32.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/63/70/2bf7780ad2d390a8d301ad0b550f1581eadbd9a20f896afe06353c2a2913/requests-2.32.3.tar.gz", hash = "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760", size = 131218 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl", hash = "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6", size = 64928 },
 ]
 
 [[package]]
@@ -421,12 +497,33 @@ wheels = [
 ]
 
 [[package]]
+name = "rsa"
+version = "4.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/aa/65/7d973b89c4d2351d7fb232c2e452547ddfa243e93131e7cfa766da627b52/rsa-4.9.tar.gz", hash = "sha256:e38464a49c6c85d7f1351b0126661487a7e0a14a50f1675ec50eb34d4f20ef21", size = 29711 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/97/fa78e3d2f65c02c8e1268b9aba606569fe97f6c8f7c2d74394553347c145/rsa-4.9-py3-none-any.whl", hash = "sha256:90260d9058e514786967344d0ef75fa8727eed8a7d2e43ce9f4bcf1b536174f7", size = 34315 },
+]
+
+[[package]]
 name = "shellingham"
 version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755 },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050 },
 ]
 
 [[package]]
@@ -484,6 +581,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/82/5c/e6082df02e215b846b4b8c0b887a64d7d08ffaba30605502639d44c06b82/typing_inspection-0.4.0.tar.gz", hash = "sha256:9765c87de36671694a67904bf2c96e395be9c6439bb6c87b5142569dcdd65122", size = 76222 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/31/08/aa4fdfb71f7de5176385bd9e90852eaf6b5d622735020ad600f2bab54385/typing_inspection-0.4.0-py3-none-any.whl", hash = "sha256:50e72559fcd2a6367a19f7a7e610e6afcb9fac940c650290eed893d61386832f", size = 14125 },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8a/78/16493d9c386d8e60e442a35feac5e00f0913c0f4b7c217c11e8ec2ff53e0/urllib3-2.4.0.tar.gz", hash = "sha256:414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466", size = 390672 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6b/11/cc635220681e93a0183390e26485430ca2c7b5f9d33b15c74c2861cb8091/urllib3-2.4.0-py3-none-any.whl", hash = "sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813", size = 128680 },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -11,7 +11,6 @@ dependencies = [
     { name = "httpx" },
     { name = "pydantic-settings" },
     { name = "python-jose" },
-    { name = "requests" },
 ]
 
 [package.dev-dependencies]
@@ -26,7 +25,6 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "pydantic-settings", specifier = ">=2.8.1" },
     { name = "python-jose", specifier = ">=3.4.0" },
-    { name = "requests", specifier = ">=2.32.3" },
 ]
 
 [package.metadata.requires-dev]
@@ -64,28 +62,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1c/ab/c9f1e32b7b1bf505bf26f0ef697775960db7932abeb7b516de930ba2705f/certifi-2025.1.31.tar.gz", hash = "sha256:3d5da6925056f6f18f119200434a4780a94263f10d1c21d032a6f6b2baa20651", size = 167577 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/38/fc/bce832fd4fd99766c04d1ee0eead6b0ec6486fb100ae5e74c1d91292b982/certifi-2025.1.31-py3-none-any.whl", hash = "sha256:ca78db4565a652026a4db2bcdf68f2fb589ea80d0be70e03929ed730746b84fe", size = 166393 },
-]
-
-[[package]]
-name = "charset-normalizer"
-version = "3.4.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/16/b0/572805e227f01586461c80e0fd25d65a2115599cc9dad142fee4b747c357/charset_normalizer-3.4.1.tar.gz", hash = "sha256:44251f18cd68a75b56585dd00dae26183e102cd5e0f9f1466e6df5da2ed64ea3", size = 123188 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/94/ce8e6f63d18049672c76d07d119304e1e2d7c6098f0841b51c666e9f44a0/charset_normalizer-3.4.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:aabfa34badd18f1da5ec1bc2715cadc8dca465868a4e73a0173466b688f29dda", size = 195698 },
-    { url = "https://files.pythonhosted.org/packages/24/2e/dfdd9770664aae179a96561cc6952ff08f9a8cd09a908f259a9dfa063568/charset_normalizer-3.4.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:22e14b5d70560b8dd51ec22863f370d1e595ac3d024cb8ad7d308b4cd95f8313", size = 140162 },
-    { url = "https://files.pythonhosted.org/packages/24/4e/f646b9093cff8fc86f2d60af2de4dc17c759de9d554f130b140ea4738ca6/charset_normalizer-3.4.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8436c508b408b82d87dc5f62496973a1805cd46727c34440b0d29d8a2f50a6c9", size = 150263 },
-    { url = "https://files.pythonhosted.org/packages/5e/67/2937f8d548c3ef6e2f9aab0f6e21001056f692d43282b165e7c56023e6dd/charset_normalizer-3.4.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2d074908e1aecee37a7635990b2c6d504cd4766c7bc9fc86d63f9c09af3fa11b", size = 142966 },
-    { url = "https://files.pythonhosted.org/packages/52/ed/b7f4f07de100bdb95c1756d3a4d17b90c1a3c53715c1a476f8738058e0fa/charset_normalizer-3.4.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:955f8851919303c92343d2f66165294848d57e9bba6cf6e3625485a70a038d11", size = 144992 },
-    { url = "https://files.pythonhosted.org/packages/96/2c/d49710a6dbcd3776265f4c923bb73ebe83933dfbaa841c5da850fe0fd20b/charset_normalizer-3.4.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:44ecbf16649486d4aebafeaa7ec4c9fed8b88101f4dd612dcaf65d5e815f837f", size = 147162 },
-    { url = "https://files.pythonhosted.org/packages/b4/41/35ff1f9a6bd380303dea55e44c4933b4cc3c4850988927d4082ada230273/charset_normalizer-3.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0924e81d3d5e70f8126529951dac65c1010cdf117bb75eb02dd12339b57749dd", size = 140972 },
-    { url = "https://files.pythonhosted.org/packages/fb/43/c6a0b685fe6910d08ba971f62cd9c3e862a85770395ba5d9cad4fede33ab/charset_normalizer-3.4.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:2967f74ad52c3b98de4c3b32e1a44e32975e008a9cd2a8cc8966d6a5218c5cb2", size = 149095 },
-    { url = "https://files.pythonhosted.org/packages/4c/ff/a9a504662452e2d2878512115638966e75633519ec11f25fca3d2049a94a/charset_normalizer-3.4.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:c75cb2a3e389853835e84a2d8fb2b81a10645b503eca9bcb98df6b5a43eb8886", size = 152668 },
-    { url = "https://files.pythonhosted.org/packages/6c/71/189996b6d9a4b932564701628af5cee6716733e9165af1d5e1b285c530ed/charset_normalizer-3.4.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:09b26ae6b1abf0d27570633b2b078a2a20419c99d66fb2823173d73f188ce601", size = 150073 },
-    { url = "https://files.pythonhosted.org/packages/e4/93/946a86ce20790e11312c87c75ba68d5f6ad2208cfb52b2d6a2c32840d922/charset_normalizer-3.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:fa88b843d6e211393a37219e6a1c1df99d35e8fd90446f1118f4216e307e48cd", size = 145732 },
-    { url = "https://files.pythonhosted.org/packages/cd/e5/131d2fb1b0dddafc37be4f3a2fa79aa4c037368be9423061dccadfd90091/charset_normalizer-3.4.1-cp313-cp313-win32.whl", hash = "sha256:eb8178fe3dba6450a3e024e95ac49ed3400e506fd4e9e5c32d30adda88cbd407", size = 95391 },
-    { url = "https://files.pythonhosted.org/packages/27/f2/4f9a69cc7712b9b5ad8fdb87039fd89abba997ad5cbe690d1835d40405b0/charset_normalizer-3.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:b1ac5992a838106edb89654e0aebfc24f5848ae2547d22c2c3f66454daa11971", size = 102702 },
-    { url = "https://files.pythonhosted.org/packages/0e/f6/65ecc6878a89bb1c23a086ea335ad4bf21a588990c3f535a227b9eea9108/charset_normalizer-3.4.1-py3-none-any.whl", hash = "sha256:d98b1668f06378c6dbefec3b92299716b931cd4e6061f3c875a71ced1780ab85", size = 49767 },
 ]
 
 [[package]]
@@ -486,21 +462,6 @@ wheels = [
 ]
 
 [[package]]
-name = "requests"
-version = "2.32.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "certifi" },
-    { name = "charset-normalizer" },
-    { name = "idna" },
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/63/70/2bf7780ad2d390a8d301ad0b550f1581eadbd9a20f896afe06353c2a2913/requests-2.32.3.tar.gz", hash = "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760", size = 131218 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl", hash = "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6", size = 64928 },
-]
-
-[[package]]
 name = "rich"
 version = "14.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -612,15 +573,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/82/5c/e6082df02e215b846b4b8c0b887a64d7d08ffaba30605502639d44c06b82/typing_inspection-0.4.0.tar.gz", hash = "sha256:9765c87de36671694a67904bf2c96e395be9c6439bb6c87b5142569dcdd65122", size = 76222 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/31/08/aa4fdfb71f7de5176385bd9e90852eaf6b5d622735020ad600f2bab54385/typing_inspection-0.4.0-py3-none-any.whl", hash = "sha256:50e72559fcd2a6367a19f7a7e610e6afcb9fac940c650290eed893d61386832f", size = 14125 },
-]
-
-[[package]]
-name = "urllib3"
-version = "2.4.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8a/78/16493d9c386d8e60e442a35feac5e00f0913c0f4b7c217c11e8ec2ff53e0/urllib3-2.4.0.tar.gz", hash = "sha256:414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466", size = 390672 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6b/11/cc635220681e93a0183390e26485430ca2c7b5f9d33b15c74c2861cb8091/urllib3-2.4.0-py3-none-any.whl", hash = "sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813", size = 128680 },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -16,6 +16,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
+    { name = "pytest-mock" },
 ]
 
 [package.metadata]
@@ -27,7 +28,10 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=8.3.5" }]
+dev = [
+    { name = "pytest", specifier = ">=8.3.5" },
+    { name = "pytest-mock", specifier = ">=3.14.0" },
+]
 
 [[package]]
 name = "annotated-types"
@@ -403,6 +407,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/30/3d/64ad57c803f1fa1e963a7946b6e0fea4a70df53c1a7fed304586539c2bac/pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820", size = 343634 },
+]
+
+[[package]]
+name = "pytest-mock"
+version = "3.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/90/a955c3ab35ccd41ad4de556596fa86685bf4fc5ffcc62d22d856cfd4e29a/pytest-mock-3.14.0.tar.gz", hash = "sha256:2719255a1efeceadbc056d6bf3df3d1c5015530fb40cf347c0f9afac88410bd0", size = 32814 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/3b/b26f90f74e2986a82df6e7ac7e319b8ea7ccece1caec9f8ab6104dc70603/pytest_mock-3.14.0-py3-none-any.whl", hash = "sha256:0b72c38033392a5f4621342fe11e9219ac11ec9d375f8e2a0c164539e0d70f6f", size = 9863 },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -9,6 +9,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "fastapi", extra = ["standard"] },
     { name = "httpx" },
+    { name = "pydantic-settings" },
     { name = "python-jose" },
     { name = "requests" },
 ]
@@ -23,6 +24,7 @@ dev = [
 requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.12" },
     { name = "httpx", specifier = ">=0.28.1" },
+    { name = "pydantic-settings", specifier = ">=2.8.1" },
     { name = "python-jose", specifier = ">=3.4.0" },
     { name = "requests", specifier = ">=2.32.3" },
 ]
@@ -383,6 +385,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/fd/24ea4302d7a527d672c5be06e17df16aabfb4e9fdc6e0b345c21580f3d2a/pydantic_core-2.33.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:401d7b76e1000d0dd5538e6381d28febdcacb097c8d340dde7d7fc6e13e9f95d", size = 1812963 },
     { url = "https://files.pythonhosted.org/packages/5f/95/4fbc2ecdeb5c1c53f1175a32d870250194eb2fdf6291b795ab08c8646d5d/pydantic_core-2.33.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7aeb055a42d734c0255c9e489ac67e75397d59c6fbe60d155851e9782f276a9c", size = 1986896 },
     { url = "https://files.pythonhosted.org/packages/71/ae/fe31e7f4a62431222d8f65a3bd02e3fa7e6026d154a00818e6d30520ea77/pydantic_core-2.33.1-cp313-cp313t-win_amd64.whl", hash = "sha256:338ea9b73e6e109f15ab439e62cb3b78aa752c7fd9536794112e14bee02c8d18", size = 1931810 },
+]
+
+[[package]]
+name = "pydantic-settings"
+version = "2.8.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/88/82/c79424d7d8c29b994fb01d277da57b0a9b09cc03c3ff875f9bd8a86b2145/pydantic_settings-2.8.1.tar.gz", hash = "sha256:d5c663dfbe9db9d5e1c646b2e161da12f0d734d422ee56f567d0ea2cee4e8585", size = 83550 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/53/a64f03044927dc47aafe029c42a5b7aabc38dfb813475e0e1bf71c4a59d0/pydantic_settings-2.8.1-py3-none-any.whl", hash = "sha256:81942d5ac3d905f7f3ee1a70df5dfb62d5569c12f51a5a647defc1c3d9ee2e9c", size = 30839 },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -15,6 +15,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "polyfactory" },
     { name = "pytest" },
     { name = "pytest-mock" },
 ]
@@ -29,6 +30,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "polyfactory", specifier = ">=2.21.0" },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest-mock", specifier = ">=3.14.0" },
 ]
@@ -117,6 +119,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/48/ce/13508a1ec3f8bb981ae4ca79ea40384becc868bfae97fd1c942bb3a001b1/email_validator-2.2.0.tar.gz", hash = "sha256:cb690f344c617a714f22e66ae771445a1ceb46821152df8e165c5f9a364582b7", size = 48967 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/ee/bf0adb559ad3c786f12bcbc9296b3f5675f529199bef03e2df281fa1fadb/email_validator-2.2.0-py3-none-any.whl", hash = "sha256:561977c2d73ce3611850a06fa56b414621e0c8faa9d66f2611407d87465da631", size = 33521 },
+]
+
+[[package]]
+name = "faker"
+version = "37.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ba/a6/b77f42021308ec8b134502343da882c0905d725a4d661c7adeaf7acaf515/faker-37.1.0.tar.gz", hash = "sha256:ad9dc66a3b84888b837ca729e85299a96b58fdaef0323ed0baace93c9614af06", size = 1875707 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/a1/8936bc8e79af80ca38288dd93ed44ed1f9d63beb25447a4c59e746e01f8d/faker-37.1.0-py3-none-any.whl", hash = "sha256:dc2f730be71cb770e9c715b13374d80dbcee879675121ab51f9683d262ae9a1c", size = 1918783 },
 ]
 
 [[package]]
@@ -309,6 +323,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556 },
+]
+
+[[package]]
+name = "polyfactory"
+version = "2.21.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "faker" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bd/d0/8ce6a9912a6f1077710ebc46a6aa9a79a64a06b69d2d6b4ccefc9765ce8f/polyfactory-2.21.0.tar.gz", hash = "sha256:a6d8dba91b2515d744cc014b5be48835633f7ccb72519a68f8801759e5b1737a", size = 246314 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/ba/c148fba517a0aaccfc4fca5e61bf2a051e084a417403e930dc615886d4e6/polyfactory-2.21.0-py3-none-any.whl", hash = "sha256:9483b764756c8622313d99f375889b1c0d92f09affb05742d7bcfa2b5198d8c5", size = 60875 },
 ]
 
 [[package]]
@@ -573,6 +600,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/82/5c/e6082df02e215b846b4b8c0b887a64d7d08ffaba30605502639d44c06b82/typing_inspection-0.4.0.tar.gz", hash = "sha256:9765c87de36671694a67904bf2c96e395be9c6439bb6c87b5142569dcdd65122", size = 76222 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/31/08/aa4fdfb71f7de5176385bd9e90852eaf6b5d622735020ad600f2bab54385/typing_inspection-0.4.0-py3-none-any.whl", hash = "sha256:50e72559fcd2a6367a19f7a7e610e6afcb9fac940c650290eed893d61386832f", size = 14125 },
+]
+
+[[package]]
+name = "tzdata"
+version = "2025.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/32/1a225d6164441be760d75c2c42e2780dc0873fe382da3e98a2e1e48361e5/tzdata-2025.2.tar.gz", hash = "sha256:b60a638fcc0daffadf82fe0f57e53d06bdec2f36c4df66280ae79bce6bd6f2b9", size = 196380 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/23/c7abc0ca0a1526a0774eca151daeb8de62ec457e77262b66b359c3c7679e/tzdata-2025.2-py2.py3-none-any.whl", hash = "sha256:1a403fada01ff9221ca8044d701868fa132215d84beb92242d9acd2147f667a8", size = 347839 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

[AAI-175](https://biocloud.atlassian.net/jira/software/c/projects/AAI/boards/53?assignee=63f30233526117e1514b222b&selectedIssue=AAI-175): Create and test a decorator/FastAPI dependency that validates JWT tokens for AAI Backend
[AAI-180](https://biocloud.atlassian.net/jira/software/c/projects/AAI/boards/53?assignee=63f30233526117e1514b222b&selectedIssue=AAI-180): Integrate Auth0 Management API in aai-backend

## Changes

- Have a way to mark each API route as requiring JWT validation
- Have unit tests that only pass when a protected route gets a valid JWT
- Implement Auth0 Management API integration. This allows ommunication with Auth0 for role and metadata management.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit / integration tests that prove my fix is effective or that my feature works
- [x] I have run all tests locally and they pass
- [x] I have updated the documentation (if applicable)

## How to Test Manually (if necessary)

For manual testing, follow these steps:
1. Create a .env and put in the vars referenced in the code, most of which can be found from Auth0 AAI Backend app
2. Run the server
3. Get an access token from logging into Auth0/using the Auth0 debugger and then use postman or similar tools and call the endpoint localhost:8000/private with the access token as a Bearer
4. Inspect the response


[AAI-175]: https://biocloud.atlassian.net/browse/AAI-175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAI-180]: https://biocloud.atlassian.net/browse/AAI-180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ