### PR TITLE
AAI-204 Automatically build Docker image and push to AWS ECR via GitHub Actions

### DIFF
--- a/.github/workflows/build-ecr.yml
+++ b/.github/workflows/build-ecr.yml
@@ -11,8 +11,8 @@ permissions:
   actions: read
 
 env:
-  AWS_REGION: ap-southeast-2  # Change to your AWS region
-  ECR_REPOSITORY: aai-backend  # Change to your repo name
+  AWS_REGION: ap-southeast-2
+  ECR_REPOSITORY: aai-backend
   IMAGE_TAG: latest
 
 jobs:

--- a/.github/workflows/build-ecr.yml
+++ b/.github/workflows/build-ecr.yml
@@ -1,0 +1,43 @@
+name: Build and Push Docker Image to ECR
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  id-token: write  # Required for OIDC
+  actions: read
+
+env:
+  AWS_REGION: ap-southeast-2  # Change to your AWS region
+  ECR_REPOSITORY: aai-backend  # Change to your repo name
+  IMAGE_TAG: latest
+
+jobs:
+  build-and-push:
+    name: Build and Push to ECR
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::232870232581:role/aai-backend-container-build
+          role-session-name: github-actions-ecr
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build, Tag, and Push Docker image
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        run: |
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG

--- a/.github/workflows/build-ecr.yml
+++ b/.github/workflows/build-ecr.yml
@@ -35,6 +35,15 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
 
+      - name: Create .env File from Secrets
+        run: |
+          cat <<EOF > .env
+          AUTH0_DOMAIN=${{ secrets.AUTH0_DOMAIN }}
+          AUTH0_MANAGEMENT_ID=${{ secrets.AUTH0_MANAGEMENT_ID }}
+          AUTH0_MANAGEMENT_SECRET=${{ secrets.AUTH0_MANAGEMENT_SECRET }}
+          AUTH0_AUDIENCE=${{ secrets.AUTH0_AUDIENCE }}
+          EOF
+
       - name: Build, Tag, and Push Docker image
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM ghcr.io/astral-sh/uv:python3.13-alpine
+ADD . /app
+WORKDIR /app
+RUN uv sync --locked
+CMD ["uv", "run", "fastapi", "run", "--host", "0.0.0.0", "--port", "8000", "--workers", "2"]


### PR DESCRIPTION
## Description

[AAI-204](https://biocloud.atlassian.net/browse/AAI-204): build the app as a Docker image and push it to AWS ECR so we can easily deploy it

## Changes

- Dockerfile to build the Docker image
- GitHub Action to push to AWS when we commit to main

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit / integration tests that prove my fix is effective or that my feature works
- [x] I have run all tests locally and they pass
- [x] I have updated the documentation (if applicable)



[AAI-204]: https://biocloud.atlassian.net/browse/AAI-204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ