### PR TITLE
Rework of settings handling: make sure settings can always be overridden easily for testing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,5 +6,7 @@ AUTH0_AUDIENCE=https://audience.com/api
 # JWT secret key: used to provide some protection around registration
 # Generate with: python -c "import secrets; print(secrets.token_urlsafe(32))"
 JWT_SECRET_KEY=secret-key
-# pydantic-settings requires a specific format for lists, check quotes
-CORS_ALLOWED_ORIGINS='["http://localhost:8000"]'
+# Comma-separated list of allowed origins. Note we
+#   don't process this with pydantic-settings as it needs
+#   to be used before the FastAPI app loads
+CORS_ALLOWED_ORIGINS=http://localhost:8000

--- a/auth/config.py
+++ b/auth/config.py
@@ -9,8 +9,10 @@ class Settings(BaseSettings):
     auth0_management_secret: str
     auth0_audience: str
     jwt_secret_key: str
-    cors_allowed_origins: list[str]
     auth0_algorithms: list[str] = ["RS256"]
+    # Note we process this separately in app startup as it needs
+    #   to be available before the app starts
+    cors_allowed_origins: str
 
     model_config = SettingsConfigDict(env_file=".env")
 

--- a/auth/management.py
+++ b/auth/management.py
@@ -1,10 +1,9 @@
 import httpx
 
-from .config import get_settings
+from .config import Settings
 
 
-def get_management_token():
-    settings = get_settings()
+def get_management_token(settings: Settings):
     url = f"https://{settings.auth0_domain}/oauth/token"
     payload = {
         "grant_type": "client_credentials",

--- a/main.py
+++ b/main.py
@@ -12,7 +12,7 @@ from routers import galaxy_register, user
 #   allowed_origins before we load the app
 load_dotenv()
 ALLOWED_ORIGINS = [origin.strip()
-                   for origin in os.getenv("CORS_ALLOWED_ORIGINS").split()]
+                   for origin in os.getenv("CORS_ALLOWED_ORIGINS", "").split(",")]
 
 app = FastAPI()
 app.add_middleware(

--- a/main.py
+++ b/main.py
@@ -1,32 +1,27 @@
-from contextlib import asynccontextmanager
+import os
 
+from dotenv import load_dotenv
 from fastapi import FastAPI
 from starlette.middleware.cors import CORSMiddleware
 
-from auth.config import get_settings
 from routers import galaxy_register, user
 
+# Load .env to get CORS_ALLOWED_ORIGINS.
+# Note that for most env variables, we use pydantic-settings
+#   and load them via auth.config. But we need the
+#   allowed_origins before we load the app
+load_dotenv()
+ALLOWED_ORIGINS = [origin.strip()
+                   for origin in os.getenv("CORS_ALLOWED_ORIGINS").split()]
 
-@asynccontextmanager
-async def lifespan(app: FastAPI):
-    """
-    Set up CORS middleware after startup so we can override it in testing
-    :param app:
-    :return:
-    """
-    settings = app.dependency_overrides.get(get_settings, get_settings)()
-
-    app.add_middleware(
-        CORSMiddleware,
-        allow_origins=settings.cors_allowed_origins,
-        allow_credentials=True,
-        allow_methods=["*"],
-        allow_headers=["*"]
-    )
-
-    yield
-
-app = FastAPI(lifespan=lifespan)
+app = FastAPI()
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=ALLOWED_ORIGINS,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"]
+)
 
 
 @app.get("/")

--- a/routers/galaxy_register.py
+++ b/routers/galaxy_register.py
@@ -36,7 +36,7 @@ def register(
 
     url = f"https://{settings.auth0_domain}/api/v2/users"
     logger.debug("Getting management token.")
-    management_token = get_management_token()
+    management_token = get_management_token(settings=settings)
     headers = {"Authorization": f"Bearer {management_token}"}
     user_data = registration_data.to_auth0_create_user_data()
     logger.debug("Registering with Auth0 management API")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ def mock_settings():
         auth0_management_secret="mock-secret",
         auth0_audience="mock-audience",
         jwt_secret_key="mock-secret-key",
-        cors_allowed_origins=["http://test"],
+        cors_allowed_origins="http://test",
         auth0_algorithms=["HS256"]
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ def mock_settings():
         auth0_management_secret="mock-secret",
         auth0_audience="mock-audience",
         jwt_secret_key="mock-secret-key",
-        cors_allowed_origins="http://test",
+        cors_allowed_origins="https://test",
         auth0_algorithms=["HS256"]
     )
 

--- a/tests/test_auth_management.py
+++ b/tests/test_auth_management.py
@@ -1,22 +1,12 @@
 from unittest.mock import patch
 
-from auth.config import Settings
 from auth.management import get_management_token
 
 
-def test_get_management_token_success():
-    with patch("auth.management.httpx.post") as mock_post, \
-         patch("auth.management.get_settings", return_value=Settings(
-            auth0_domain="yourdomain.auth0.com",
-            auth0_management_id="testid",
-            auth0_management_secret="testsecret",
-            auth0_audience="https://your-auth0-api-audience",
-            jwt_secret_key="supersecret",
-            cors_allowed_origins=["*"]
-        )):
-
+def test_get_management_token_success(mock_settings):
+    with patch("auth.management.httpx.post") as mock_post:
         mock_post.return_value.json.return_value = {"access_token": "abc123"}
         mock_post.return_value.raise_for_status = lambda: None
 
-        token = get_management_token()
+        token = get_management_token(settings=mock_settings)
         assert token == "abc123"

--- a/tests/test_auth_validator.py
+++ b/tests/test_auth_validator.py
@@ -7,20 +7,12 @@ from auth.config import Settings
 from auth.validator import get_rsa_key
 
 
-def test_get_rsa_key_returns_key():
+def test_get_rsa_key_returns_key(mock_settings: Settings):
     token = jwt.encode({"some": "payload"}, "secret", algorithm="HS256")
     unverified_header = {"kid": "testkey"}
 
     with patch("auth.validator.jwt.get_unverified_header", return_value=unverified_header), \
-         patch("auth.validator.httpx.get") as mock_get, \
-         patch("auth.validator.get_settings", return_value=Settings(
-             auth0_domain="yourdomain.auth0.com",
-             auth0_management_id="testid",
-             auth0_management_secret="testsecret",
-             auth0_audience="https://your-auth0-api-audience",
-             jwt_secret_key="supersecret",
-             cors_allowed_origins=["*"]
-         )):
+         patch("auth.validator.httpx.get") as mock_get:
 
         mock_get.return_value.json.return_value = {
             "keys": [{
@@ -32,6 +24,6 @@ def test_get_rsa_key_returns_key():
             }]
         }
 
-        key = get_rsa_key(token)
+        key = get_rsa_key(token, settings=mock_settings)
         assert key is not None
         assert isinstance(key, RSAKey)

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -4,7 +4,6 @@ import pytest
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
-from auth.config import Settings
 from main import app
 from schemas.service import AppMetadata, Group, Resource, Service
 from schemas.tokens import AccessTokenPayload
@@ -15,23 +14,6 @@ client = TestClient(app)
 
 
 # --- Test Fixtures ---
-@pytest.fixture(autouse=True)
-def mock_auth_settings(mocker):
-    """Fixture to mock auth settings globally"""
-    mock_settings = Settings(
-        auth0_domain="mock-domain.com",
-        auth0_audience="mock-audience",
-        auth0_management_id="mock-id",
-        auth0_management_secret="mock-secret",
-        jwt_secret_key="mock-secret",
-        cors_allowed_origins="http://test",
-        auth0_algorithms=["RS256"],
-    )
-    mocker.patch("auth.config.get_settings", return_value=mock_settings)
-    mocker.patch("auth.management.get_settings", return_value=mock_settings)
-    return mock_settings
-
-
 @pytest.fixture
 def mock_auth_token(mocker):
     """Fixture to mock authentication token"""
@@ -105,7 +87,7 @@ def test_endpoints_require_auth(endpoint):
 
 # --- Service Endpoints (GET) ---
 def test_get_all_services(
-    mock_auth_settings, mock_auth_token, auth_headers, mock_user_data, mocker
+    mock_auth_token, auth_headers, mock_user_data, mocker
 ):
     """Test getting all services"""
     mocker.patch(
@@ -126,7 +108,7 @@ def test_get_all_services(
 
 
 def test_get_approved_services(
-    mock_auth_settings, mock_auth_token, auth_headers, mock_user_data, mocker
+    mock_auth_token, auth_headers, mock_user_data, mocker
 ):
     """Test getting approved services"""
     mocker.patch(
@@ -149,7 +131,7 @@ def test_get_approved_services(
 
 
 def test_get_pending_services(
-    mock_auth_settings, mock_auth_token, auth_headers, mock_user_data, mocker
+    mock_auth_token, auth_headers, mock_user_data, mocker
 ):
     """Test getting pending services"""
     mocker.patch(
@@ -172,7 +154,7 @@ def test_get_pending_services(
 
 
 def test_get_services_failed_fetch(
-    mock_auth_settings, mock_auth_token, auth_headers, mocker
+    mock_auth_token, auth_headers, mocker
 ):
     """Test handling of failed API calls"""
     mocker.patch(
@@ -189,7 +171,7 @@ def test_get_services_failed_fetch(
 
 
 def test_get_services_empty_metadata(
-    mock_auth_settings, mock_auth_token, auth_headers, mocker
+    mock_auth_token, auth_headers, mocker
 ):
     """Test handling of empty metadata"""
     empty_user = Auth0UserFactory.build(
@@ -206,7 +188,7 @@ def test_get_services_empty_metadata(
 
 
 def test_get_services_no_metadata(
-    mock_auth_settings, mock_auth_token, auth_headers, mocker
+    mock_auth_token, auth_headers, mocker
 ):
     """Test handling of missing metadata"""
     no_metadata_user = Auth0UserFactory.build(app_metadata=AppMetadata())
@@ -222,7 +204,7 @@ def test_get_services_no_metadata(
 
 # --- Resource Endpoints (GET) ---
 def test_get_all_resources(
-    mock_auth_settings, mock_auth_token, auth_headers, mock_user_data, mocker
+    mock_auth_token, auth_headers, mock_user_data, mocker
 ):
     """Test getting all resources"""
     mocker.patch(
@@ -244,7 +226,7 @@ def test_get_all_resources(
 
 
 def test_get_approved_resources(
-    mock_auth_settings, mock_auth_token, auth_headers, mock_user_data, mocker
+    mock_auth_token, auth_headers, mock_user_data, mocker
 ):
     """Test getting approved resources"""
     mocker.patch(
@@ -267,7 +249,7 @@ def test_get_approved_resources(
 
 
 def test_get_resources_empty_metadata(
-    mock_auth_settings, mock_auth_token, auth_headers, mocker
+    mock_auth_token, auth_headers, mocker
 ):
     """Test handling of empty resource metadata"""
     empty_user = Auth0UserFactory.build(app_metadata=AppMetadata(services=[], groups=[]),
@@ -283,7 +265,7 @@ def test_get_resources_empty_metadata(
 
 
 def test_get_resources_no_metadata(
-    mock_auth_settings, mock_auth_token, auth_headers, mocker
+    mock_auth_token, auth_headers, mocker
 ):
     """Test handling of missing resource metadata"""
     no_metadata_user = Auth0UserFactory.build(app_metadata=AppMetadata())
@@ -299,7 +281,7 @@ def test_get_resources_no_metadata(
 
 # --- Service Request Endpoints (POST) ---
 def test_request_service_success(
-    mock_auth_settings, mock_auth_token, auth_headers, mock_user_data, mocker
+    mock_auth_token, auth_headers, mock_user_data, mocker
 ):
     """Test successful service request"""
     mocker.patch("routers.user.get_user_data", return_value=mock_user_data)
@@ -323,7 +305,7 @@ def test_request_service_success(
 
 
 def test_request_service_duplicate(
-    mock_auth_settings, mock_auth_token, auth_headers, mock_user_data, mocker
+    mock_auth_token, auth_headers, mock_user_data, mocker
 ):
     """Test duplicate service request"""
     mocker.patch("routers.user.get_user_data", return_value=mock_user_data)
@@ -347,7 +329,7 @@ def test_request_service_duplicate(
 
 
 def test_request_service_user_mismatch(
-    mock_auth_settings, mock_auth_token, auth_headers, mock_user_data, mocker
+    mock_auth_token, auth_headers, mock_user_data
 ):
     """Test service request with mismatched user"""
     request_payload = {
@@ -368,7 +350,7 @@ def test_request_service_user_mismatch(
 
 # --- Resource Request Endpoints (POST) ---
 def test_request_resource_success(
-    mock_auth_settings, mock_auth_token, auth_headers, mock_user_data, mocker
+    mock_auth_token, auth_headers, mock_user_data, mocker
 ):
     """Test successful resource request"""
     mocker.patch("routers.user.get_user_data", return_value=mock_user_data)
@@ -392,7 +374,7 @@ def test_request_resource_success(
 
 
 def test_request_resource_user_mismatch(
-    mock_auth_settings, mock_auth_token, auth_headers, mock_user_data, mocker
+    mock_auth_token, auth_headers, mock_user_data
 ):
     """Test resource request with mismatched user"""
     request_payload = {
@@ -413,7 +395,7 @@ def test_request_resource_user_mismatch(
 
 
 def test_request_resource_non_approved_service(
-    mock_auth_settings, mock_auth_token, auth_headers, mock_user_data, mocker
+    mock_auth_token, auth_headers, mock_user_data, mocker
 ):
     """Test resource request for non-approved service"""
     mocker.patch("routers.user.get_user_data", return_value=mock_user_data)
@@ -441,7 +423,7 @@ def test_request_resource_non_approved_service(
 
 
 def test_request_resource_duplicate(
-    mock_auth_settings, mock_auth_token, auth_headers, mock_user_data, mocker
+    mock_auth_token, auth_headers, mock_user_data, mocker
 ):
     """Test duplicate resource request"""
     mocker.patch("routers.user.get_user_data", return_value=mock_user_data)
@@ -466,7 +448,7 @@ def test_request_resource_duplicate(
 
 
 def test_request_resource_invalid_service(
-    mock_auth_settings, mock_auth_token, auth_headers, mock_user_data, mocker
+    mock_auth_token, auth_headers, mock_user_data, mocker
 ):
     """Test resource request for non-existent service"""
     mocker.patch("routers.user.get_user_data", return_value=mock_user_data)

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -281,7 +281,8 @@ def test_get_resources_no_metadata(
 
 # --- Service Request Endpoints (POST) ---
 def test_request_service_success(
-    mock_auth_token, auth_headers, mock_user_data, mocker
+    mock_auth_token, auth_headers, mock_user_data, mocker,
+        client_with_settings_override
 ):
     """Test successful service request"""
     mocker.patch("routers.user.get_user_data", return_value=mock_user_data)
@@ -296,7 +297,7 @@ def test_request_service_success(
         "user_id": mock_auth_token.sub,
     }
 
-    response = client.post(
+    response = client_with_settings_override.post(
         "/me/request/service", json=new_service, headers=auth_headers
     )
     assert response.status_code == 200
@@ -305,7 +306,8 @@ def test_request_service_success(
 
 
 def test_request_service_duplicate(
-    mock_auth_token, auth_headers, mock_user_data, mocker
+    mock_auth_token, auth_headers, mock_user_data, mocker,
+        client_with_settings_override
 ):
     """Test duplicate service request"""
     mocker.patch("routers.user.get_user_data", return_value=mock_user_data)
@@ -319,7 +321,7 @@ def test_request_service_duplicate(
         "user_id": mock_auth_token.sub,
     }
 
-    response = client.post(
+    response = client_with_settings_override.post(
         "/me/request/service", json=existing_service, headers=auth_headers
     )
     assert response.status_code == 400
@@ -329,7 +331,8 @@ def test_request_service_duplicate(
 
 
 def test_request_service_user_mismatch(
-    mock_auth_token, auth_headers, mock_user_data
+    mock_auth_token, auth_headers, mock_user_data,
+        client_with_settings_override
 ):
     """Test service request with mismatched user"""
     request_payload = {
@@ -338,7 +341,7 @@ def test_request_service_user_mismatch(
         "user_id": "auth0|WRONG_USER",
     }
 
-    response = client.post(
+    response = client_with_settings_override.post(
         "/me/request/service", json=request_payload, headers=auth_headers
     )
     assert response.status_code == 403
@@ -350,7 +353,8 @@ def test_request_service_user_mismatch(
 
 # --- Resource Request Endpoints (POST) ---
 def test_request_resource_success(
-    mock_auth_token, auth_headers, mock_user_data, mocker
+    mock_auth_token, auth_headers, mock_user_data, mocker,
+        client_with_settings_override
 ):
     """Test successful resource request"""
     mocker.patch("routers.user.get_user_data", return_value=mock_user_data)
@@ -366,7 +370,7 @@ def test_request_resource_success(
         "service_id": "service1",
     }
 
-    response = client.post(
+    response = client_with_settings_override.post(
         "/me/request/service1/resource-new", json=request_payload, headers=auth_headers
     )
     assert response.status_code == 200
@@ -374,7 +378,8 @@ def test_request_resource_success(
 
 
 def test_request_resource_user_mismatch(
-    mock_auth_token, auth_headers, mock_user_data
+    mock_auth_token, auth_headers, mock_user_data,
+        client_with_settings_override
 ):
     """Test resource request with mismatched user"""
     request_payload = {
@@ -384,7 +389,7 @@ def test_request_resource_user_mismatch(
         "service_id": "service1",
     }
 
-    response = client.post(
+    response = client_with_settings_override.post(
         "/me/request/service1/res-invalid", json=request_payload, headers=auth_headers
     )
     assert response.status_code == 403
@@ -395,7 +400,8 @@ def test_request_resource_user_mismatch(
 
 
 def test_request_resource_non_approved_service(
-    mock_auth_token, auth_headers, mock_user_data, mocker
+    mock_auth_token, auth_headers, mock_user_data, mocker,
+        client_with_settings_override
 ):
     """Test resource request for non-approved service"""
     mocker.patch("routers.user.get_user_data", return_value=mock_user_data)
@@ -410,7 +416,7 @@ def test_request_resource_non_approved_service(
         "service_id": "service2",
     }
 
-    response = client.post(
+    response = client_with_settings_override.post(
         "/me/request/service2/blocked-resource",
         json=request_payload,
         headers=auth_headers,
@@ -423,7 +429,8 @@ def test_request_resource_non_approved_service(
 
 
 def test_request_resource_duplicate(
-    mock_auth_token, auth_headers, mock_user_data, mocker
+    mock_auth_token, auth_headers, mock_user_data, mocker,
+        client_with_settings_override
 ):
     """Test duplicate resource request"""
     mocker.patch("routers.user.get_user_data", return_value=mock_user_data)
@@ -438,7 +445,7 @@ def test_request_resource_duplicate(
         "service_id": "service1",
     }
 
-    response = client.post(
+    response = client_with_settings_override.post(
         "/me/request/service1/resource1", json=existing_resource, headers=auth_headers
     )
     assert response.status_code == 400
@@ -448,7 +455,8 @@ def test_request_resource_duplicate(
 
 
 def test_request_resource_invalid_service(
-    mock_auth_token, auth_headers, mock_user_data, mocker
+    mock_auth_token, auth_headers, mock_user_data, mocker,
+        client_with_settings_override
 ):
     """Test resource request for non-existent service"""
     mocker.patch("routers.user.get_user_data", return_value=mock_user_data)
@@ -463,7 +471,7 @@ def test_request_resource_invalid_service(
         "service_id": "non-existent-service",
     }
 
-    response = client.post(
+    response = client_with_settings_override.post(
         "/me/request/non-existent-service/resource-invalid",
         json=request_payload,
         headers=auth_headers,

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -22,12 +22,11 @@ def mock_auth_settings(mocker):
         auth0_management_id="mock-id",
         auth0_management_secret="mock-secret",
         jwt_secret_key="mock-secret",
-        cors_allowed_origins=["http://test"],
+        cors_allowed_origins="http://test",
         auth0_algorithms=["RS256"],
     )
     mocker.patch("auth.config.get_settings", return_value=mock_settings)
     mocker.patch("auth.management.get_settings", return_value=mock_settings)
-    mocker.patch("main.get_settings", return_value=mock_settings)
     return mock_settings
 
 


### PR DESCRIPTION
Started off with a fix for a bug: tried to load settings in a `lifespan` event to allow them to be overridden easily, but it turns out this can't be done with middleware, which has to load the app. Rework so we just load the CORS settings before app startup.

However, in the process realized we needed a further rework of the way we handle settings, so that we can always override them for testing. This allows us to clean up our tests and do less mocking/setup for each test.