### PR TITLE
Add BPA Registration Endpoint

### DIFF
--- a/auth/config.py
+++ b/auth/config.py
@@ -1,5 +1,5 @@
 from functools import lru_cache
-from typing import Dict, List
+from typing import Dict
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -14,26 +14,26 @@ class Settings(BaseSettings):
     # Note we process this separately in app startup as it needs
     #   to be available before the app starts
     cors_allowed_origins: str
-    organizations: List[Dict[str, str]] = [
-        {"id": "bpa-bioinformatics-workshop", "name": "2024 Fungi Bioinformatics Workshop"},
-        {"id": "cipps", "name": "ARC for Innovations in Peptide and Protein Science (CIPPS)"},
-        {"id": "ausarg", "name": "Australian Amphibian and Reptile Genomics"},
-        {"id": "aus-avian", "name": "Australian Avian Genomics"},
-        {"id": "aus-fish", "name": "Australian Fish Genomics"},
-        {"id": "grasslands", "name": "Australian Grasslands Initiative"},
-        {"id": "fungi", "name": "Fungi Functional 'Omics"},
-        {"id": "forest-resilience", "name": "Genomics for Forest Resilience"},
-        {"id": "bpa-great-barrier-reef", "name": "Great Barrier Reef"},
-        {"id": "bpa-ipm", "name": "Integrated Pest Management 'Omics"},
-        {"id": "bpa-omg", "name": "Oz Mammals Genomics Initiative"},
-        {"id": "plant-pathogen", "name": "Plant Pathogen 'Omics"},
-        {"id": "ppa", "name": "Plant Protein Atlas"},
-        {"id": "australian-microbiome", "name": "The Australian Microbiome Initiative"},
-        {"id": "threatened-species", "name": "Threatened Species Initiative"},
-        {"id": "bpa-wheat-cultivars", "name": "Wheat Cultivars"},
-        {"id": "bpa-wheat-pathogens-genomes", "name": "Wheat Pathogens Genomes"},
-        {"id": "bpa-wheat-pathogens-transcript", "name": "Wheat Pathogens Transcript"},
-    ]
+    organizations: Dict[str, str] = {
+        "bpa-bioinformatics-workshop": "2024 Fungi Bioinformatics Workshop",
+        "cipps": "ARC for Innovations in Peptide and Protein Science (CIPPS)",
+        "ausarg": "Australian Amphibian and Reptile Genomics",
+        "aus-avian": "Australian Avian Genomics",
+        "aus-fish": "Australian Fish Genomics",
+        "grasslands": "Australian Grasslands Initiative",
+        "fungi": "Fungi Functional 'Omics",
+        "forest-resilience": "Genomics for Forest Resilience",
+        "bpa-great-barrier-reef": "Great Barrier Reef",
+        "bpa-ipm": "Integrated Pest Management 'Omics",
+        "bpa-omg": "Oz Mammals Genomics Initiative",
+        "plant-pathogen": "Plant Pathogen 'Omics",
+        "ppa": "Plant Protein Atlas",
+        "australian-microbiome": "The Australian Microbiome Initiative",
+        "threatened-species": "Threatened Species Initiative",
+        "bpa-wheat-cultivars": "Wheat Cultivars",
+        "bpa-wheat-pathogens-genomes": "Wheat Pathogens Genomes",
+        "bpa-wheat-pathogens-transcript": "Wheat Pathogens Transcript",
+    }
 
     model_config = SettingsConfigDict(env_file=".env")
 

--- a/auth/config.py
+++ b/auth/config.py
@@ -1,4 +1,5 @@
 from functools import lru_cache
+from typing import Dict, List
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -13,6 +14,26 @@ class Settings(BaseSettings):
     # Note we process this separately in app startup as it needs
     #   to be available before the app starts
     cors_allowed_origins: str
+    organizations: List[Dict[str, str]] = [
+        {"id": "bpa-bioinformatics-workshop", "name": "2024 Fungi Bioinformatics Workshop"},
+        {"id": "cipps", "name": "ARC for Innovations in Peptide and Protein Science (CIPPS)"},
+        {"id": "ausarg", "name": "Australian Amphibian and Reptile Genomics"},
+        {"id": "aus-avian", "name": "Australian Avian Genomics"},
+        {"id": "aus-fish", "name": "Australian Fish Genomics"},
+        {"id": "grasslands", "name": "Australian Grasslands Initiative"},
+        {"id": "fungi", "name": "Fungi Functional 'Omics"},
+        {"id": "forest-resilience", "name": "Genomics for Forest Resilience"},
+        {"id": "bpa-great-barrier-reef", "name": "Great Barrier Reef"},
+        {"id": "bpa-ipm", "name": "Integrated Pest Management 'Omics"},
+        {"id": "bpa-omg", "name": "Oz Mammals Genomics Initiative"},
+        {"id": "plant-pathogen", "name": "Plant Pathogen 'Omics"},
+        {"id": "ppa", "name": "Plant Protein Atlas"},
+        {"id": "australian-microbiome", "name": "The Australian Microbiome Initiative"},
+        {"id": "threatened-species", "name": "Threatened Species Initiative"},
+        {"id": "bpa-wheat-cultivars", "name": "Wheat Cultivars"},
+        {"id": "bpa-wheat-pathogens-genomes", "name": "Wheat Pathogens Genomes"},
+        {"id": "bpa-wheat-pathogens-transcript", "name": "Wheat Pathogens Transcript"},
+    ]
 
     model_config = SettingsConfigDict(env_file=".env")
 

--- a/main.py
+++ b/main.py
@@ -4,15 +4,16 @@ from dotenv import load_dotenv
 from fastapi import FastAPI
 from starlette.middleware.cors import CORSMiddleware
 
-from routers import galaxy_register, user
+from routers import bpa_register, galaxy_register, user
 
 # Load .env to get CORS_ALLOWED_ORIGINS.
 # Note that for most env variables, we use pydantic-settings
 #   and load them via auth.config. But we need the
 #   allowed_origins before we load the app
 load_dotenv()
-ALLOWED_ORIGINS = [origin.strip()
-                   for origin in os.getenv("CORS_ALLOWED_ORIGINS", "").split(",")]
+ALLOWED_ORIGINS = [
+    origin.strip() for origin in os.getenv("CORS_ALLOWED_ORIGINS", "").split(",")
+]
 
 app = FastAPI()
 app.add_middleware(
@@ -20,7 +21,7 @@ app.add_middleware(
     allow_origins=ALLOWED_ORIGINS,
     allow_credentials=True,
     allow_methods=["*"],
-    allow_headers=["*"]
+    allow_headers=["*"],
 )
 
 
@@ -30,4 +31,5 @@ def public_route():
 
 
 app.include_router(user.router)
+app.include_router(bpa_register.router)
 app.include_router(galaxy_register.router)

--- a/routers/bpa_register.py
+++ b/routers/bpa_register.py
@@ -1,0 +1,118 @@
+from datetime import datetime, timezone
+from typing import Any, Dict
+
+from fastapi import APIRouter, Depends, HTTPException
+from httpx import AsyncClient
+from pydantic import BaseModel, EmailStr
+
+from auth.config import Settings, get_settings
+from auth.management import get_management_token
+from schemas.service import Resource, Service
+
+router = APIRouter(prefix="/bpa", tags=["bpa", "registration"])
+
+
+class BPARegistrationRequest(BaseModel):
+    username: str
+    fullname: str
+    email: EmailStr
+    reason: str
+    password: str
+    organizations: Dict[str, bool]
+
+
+@router.post(
+    "/register",
+    response_model=Dict[str, Any],
+    responses={
+        400: {"description": "Bad Request - Validation error"},
+        409: {"description": "Conflict - User already exists"},
+        500: {"description": "Internal server error"},
+    },
+)
+async def register_bpa_user(
+    registration: BPARegistrationRequest, settings: Settings = Depends(get_settings)
+) -> Dict[str, Any]:
+    """Register a new BPA user with selected organization resources."""
+    url = f"https://{settings.auth0_domain}/api/v2/users"
+    token = get_management_token(settings=settings)
+    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+
+    # Create BPA resources for selected organizations
+    bpa_resources = []
+    valid_org_ids = {org["id"] for org in settings.organizations}
+
+    for org_id, is_selected in registration.organizations.items():
+        if not is_selected:
+            continue
+        if org_id not in valid_org_ids:
+            raise HTTPException(
+                status_code=400, detail=f"Invalid organization ID: {org_id}"
+            )
+        org_name = next(
+            (org["name"] for org in settings.organizations if org["id"] == org_id),
+            None,
+        )
+        resource = Resource(id=org_id, name=org_name, status="pending").model_dump(
+            mode="json"
+        )
+        bpa_resources.append(resource)
+
+    # Create initial BPA service
+    bpa_service = Service(
+        name="BPA",
+        id="bpa",
+        status="pending",
+        last_updated=datetime.now(timezone.utc),
+        updated_by="system",
+        resources=bpa_resources,
+    )
+
+    user_data = {
+        "email": registration.email,
+        "password": registration.password,
+        "connection": "Username-Password-Authentication",
+        "username": registration.username,
+        "name": registration.fullname,
+        "nickname": registration.username,
+        "email_verified": False,
+        "blocked": False,
+        "verify_email": True,
+        "user_metadata": {"registration_reason": registration.reason},
+        "app_metadata": {
+            "groups": [],
+            "services": [bpa_service.model_dump(mode="json")],
+        },
+    }
+
+    name_parts = registration.fullname.split(maxsplit=1)
+    if len(name_parts) > 1:
+        user_data["given_name"] = name_parts[0]
+        user_data["family_name"] = name_parts[1]
+    else:
+        user_data["given_name"] = registration.fullname
+        user_data["family_name"] = ""
+
+    try:
+        async with AsyncClient() as client:
+            response = await client.post(url, headers=headers, json=user_data)
+
+            if response.status_code == 409:
+                raise HTTPException(
+                    status_code=409,
+                    detail="User with this email or username already exists",
+                )
+
+            if response.status_code != 201:
+                raise HTTPException(
+                    status_code=400, detail=f"Failed to create user: {response.text}"
+                )
+
+            return {"message": "User registered successfully", "user": response.json()}
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(
+            status_code=500, detail=f"Failed to register user: {str(e)}"
+        )

--- a/schemas/bpa.py
+++ b/schemas/bpa.py
@@ -1,0 +1,39 @@
+from typing import Dict, List
+
+from pydantic import BaseModel, EmailStr
+
+
+class BPAUserMetadata(BaseModel):
+    bpa: Dict[str, str] = {"registration_reason": ""}
+
+
+class BPAAppMetadata(BaseModel):
+    groups: List[Dict] = []
+    services: List[Dict] = []
+
+
+class BPARegisterData(BaseModel):
+    email: EmailStr
+    password: str
+    connection: str = "Username-Password-Authentication"
+    username: str
+    name: str
+    email_verified: bool = False
+    blocked: bool = False
+    verify_email: bool = True
+    user_metadata: BPAUserMetadata
+    app_metadata: BPAAppMetadata
+
+    @classmethod
+    def from_registration(cls, registration, bpa_service):
+        """Create BPARegisterData from registration request and BPA service."""
+        return cls(
+            email=registration.email,
+            password=registration.password,
+            username=registration.username,
+            name=registration.fullname,
+            user_metadata=BPAUserMetadata(
+                bpa={"registration_reason": registration.reason}
+            ),
+            app_metadata=BPAAppMetadata(services=[bpa_service.model_dump(mode="json")]),
+        )

--- a/tests/datagen.py
+++ b/tests/datagen.py
@@ -1,6 +1,7 @@
 from polyfactory.decorators import post_generated
 from polyfactory.factories.pydantic_factory import ModelFactory
 
+from routers.bpa_register import BPARegistrationRequest
 from schemas.galaxy import GalaxyRegistrationData
 from schemas.service import Auth0User
 from schemas.tokens import AccessTokenPayload
@@ -25,3 +26,16 @@ class GalaxyRegistrationDataFactory(ModelFactory[GalaxyRegistrationData]):
         Use the same value as password for password_confirmation.
         """
         return password
+
+
+class BPARegistrationDataFactory(ModelFactory[BPARegistrationRequest]):
+    """Factory for generating BPA registration test data."""
+
+    @classmethod
+    def get_default_organizations(cls) -> dict:
+        """Default organization selection."""
+        return {
+            "bpa-bioinformatics-workshop": True,
+            "cipps": False,
+            "ausarg": True,
+        }

--- a/tests/test_bpa_register.py
+++ b/tests/test_bpa_register.py
@@ -2,20 +2,20 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from tests.datagen import AccessTokenPayloadFactory
+from tests.datagen import AccessTokenPayloadFactory, BPARegistrationDataFactory
 
-VALID_REGISTRATION_DATA = {
-    "username": "testuser",
-    "fullname": "Test User",
-    "email": "test@example.com",
-    "reason": "Need access to BPA resources",
-    "password": "SecurePass123!",
-    "organizations": {
-        "bpa-bioinformatics-workshop": True,
-        "cipps": False,
-        "ausarg": True,
-    },
-}
+
+@pytest.fixture
+def valid_registration_data():
+    """Fixture that provides valid BPA registration data."""
+    return BPARegistrationDataFactory.build(
+        username="testuser",
+        fullname="Test User",
+        email="test@example.com",
+        reason="Need access to BPA resources",
+        password="SecurePass123!",
+        organizations=BPARegistrationDataFactory.get_default_organizations(),
+    ).model_dump()
 
 
 @pytest.fixture
@@ -31,7 +31,7 @@ def mock_auth_token(mocker):
 
 
 def test_successful_registration(
-    client_with_settings_override, mock_auth_token, mocker
+    client_with_settings_override, mock_auth_token, mocker, valid_registration_data
 ):
     """Test successful user registration with BPA service"""
     mock_response = MagicMock()
@@ -41,16 +41,16 @@ def test_successful_registration(
     mock_post = mocker.patch("httpx.AsyncClient.post", return_value=mock_response)
 
     response = client_with_settings_override.post(
-        "/bpa/register", json=VALID_REGISTRATION_DATA
+        "/bpa/register", json=valid_registration_data
     )
 
     assert response.status_code == 200
     assert response.json()["message"] == "User registered successfully"
 
     called_data = mock_post.call_args[1]["json"]
-    assert called_data["email"] == VALID_REGISTRATION_DATA["email"]
-    assert called_data["username"] == VALID_REGISTRATION_DATA["username"]
-    assert called_data["name"] == VALID_REGISTRATION_DATA["fullname"]
+    assert called_data["email"] == valid_registration_data["email"]
+    assert called_data["username"] == valid_registration_data["username"]
+    assert called_data["name"] == valid_registration_data["fullname"]
 
     app_metadata = called_data["app_metadata"]
     assert len(app_metadata["services"]) == 1
@@ -61,12 +61,12 @@ def test_successful_registration(
 
     assert (
         called_data["user_metadata"]["bpa"]["registration_reason"]
-        == VALID_REGISTRATION_DATA["reason"]
+        == valid_registration_data["reason"]
     )
 
 
 def test_registration_duplicate_user(
-    client_with_settings_override, mock_auth_token, mocker
+    client_with_settings_override, mock_auth_token, mocker, valid_registration_data
 ):
     """Test registration with duplicate user"""
     mock_response = MagicMock()
@@ -74,7 +74,7 @@ def test_registration_duplicate_user(
     mocker.patch("httpx.AsyncClient.post", return_value=mock_response)
 
     response = client_with_settings_override.post(
-        "/bpa/register", json=VALID_REGISTRATION_DATA
+        "/bpa/register", json=valid_registration_data
     )
 
     assert response.status_code == 409
@@ -82,7 +82,7 @@ def test_registration_duplicate_user(
 
 
 def test_registration_auth0_error(
-    client_with_settings_override, mock_auth_token, mocker
+    client_with_settings_override, mock_auth_token, mocker, valid_registration_data
 ):
     """Test registration with Auth0 API error"""
     mock_response = MagicMock()
@@ -91,7 +91,7 @@ def test_registration_auth0_error(
     mocker.patch("httpx.AsyncClient.post", return_value=mock_response)
 
     response = client_with_settings_override.post(
-        "/bpa/register", json=VALID_REGISTRATION_DATA
+        "/bpa/register", json=valid_registration_data
     )
 
     assert response.status_code == 400
@@ -99,10 +99,10 @@ def test_registration_auth0_error(
 
 
 def test_registration_with_invalid_organization(
-    client_with_settings_override, mock_auth_token, mocker
+    client_with_settings_override, mock_auth_token, mocker, valid_registration_data
 ):
     """Test registration with invalid organization ID"""
-    data = VALID_REGISTRATION_DATA.copy()
+    data = valid_registration_data.copy()
     data["organizations"] = {"invalid-org-id": True}
 
     response = client_with_settings_override.post("/bpa/register", json=data)
@@ -125,10 +125,10 @@ def test_registration_request_validation(client_with_settings_override):
 
 
 def test_no_selected_organizations(
-    client_with_settings_override, mock_auth_token, mocker
+    client_with_settings_override, mock_auth_token, mocker, valid_registration_data
 ):
     """Test registration with no organizations selected"""
-    data = VALID_REGISTRATION_DATA.copy()
+    data = valid_registration_data.copy()
     data["organizations"] = {
         "bpa-bioinformatics-workshop": False,
         "cipps": False,
@@ -150,10 +150,10 @@ def test_no_selected_organizations(
 
 
 def test_empty_organizations_dict(
-    client_with_settings_override, mock_auth_token, mocker
+    client_with_settings_override, mock_auth_token, mocker, valid_registration_data
 ):
     """Test registration with empty organizations dictionary"""
-    data = VALID_REGISTRATION_DATA.copy()
+    data = valid_registration_data.copy()
     data["organizations"] = {}
 
     mock_response = MagicMock()
@@ -170,9 +170,11 @@ def test_empty_organizations_dict(
     assert len(bpa_service["resources"]) == 0
 
 
-def test_registration_email_format(client_with_settings_override):
+def test_registration_email_format(
+    client_with_settings_override, valid_registration_data
+):
     """Test email format validation"""
-    data = VALID_REGISTRATION_DATA.copy()
+    data = valid_registration_data.copy()
     data["email"] = "invalid-email"
 
     response = client_with_settings_override.post("/bpa/register", json=data)
@@ -182,10 +184,14 @@ def test_registration_email_format(client_with_settings_override):
 
 
 def test_all_organizations_selected(
-    client_with_settings_override, mock_auth_token, mock_settings, mocker
+    client_with_settings_override,
+    mock_auth_token,
+    mock_settings,
+    mocker,
+    valid_registration_data,
 ):
     """Test registration with all organizations selected"""
-    data = VALID_REGISTRATION_DATA.copy()
+    data = valid_registration_data.copy()
     data["organizations"] = {k: True for k in mock_settings.organizations.keys()}
 
     mock_response = MagicMock()

--- a/tests/test_bpa_register.py
+++ b/tests/test_bpa_register.py
@@ -1,0 +1,220 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from auth.config import Settings
+from tests.datagen import AccessTokenPayloadFactory
+
+VALID_REGISTRATION_DATA = {
+    "username": "testuser",
+    "fullname": "Test User",
+    "email": "test@example.com",
+    "reason": "Need access to BPA resources",
+    "password": "SecurePass123!",
+    "organizations": {
+        "bpa-bioinformatics-workshop": True,
+        "cipps": False,
+        "ausarg": True,
+    },
+}
+
+
+@pytest.fixture
+def mock_auth_token(mocker):
+    token = AccessTokenPayloadFactory.build(
+        sub="auth0|123456789",
+        biocommons_roles=["acdc/indexd_admin"],
+    )
+    mocker.patch("auth.validator.verify_jwt", return_value=token)
+    mocker.patch("auth.management.get_management_token", return_value="mock_token")
+    mocker.patch("routers.bpa_register.get_management_token", return_value="mock_token")
+    return token
+
+
+def test_successful_registration(
+    client_with_settings_override, mock_auth_token, mocker
+):
+    """Test successful user registration with BPA service"""
+    mock_response = MagicMock()
+    mock_response.status_code = 201
+    mock_response.json.return_value = {"user_id": "auth0|123"}
+
+    mock_post = mocker.patch("httpx.AsyncClient.post", return_value=mock_response)
+
+    response = client_with_settings_override.post(
+        "/bpa/register", json=VALID_REGISTRATION_DATA
+    )
+
+    assert response.status_code == 200
+    assert response.json()["message"] == "User registered successfully"
+
+    called_data = mock_post.call_args[1]["json"]
+    assert called_data["email"] == VALID_REGISTRATION_DATA["email"]
+    assert called_data["username"] == VALID_REGISTRATION_DATA["username"]
+    assert called_data["given_name"] == "Test"
+    assert called_data["family_name"] == "User"
+
+    app_metadata = called_data["app_metadata"]
+    assert len(app_metadata["services"]) == 1
+    bpa_service = app_metadata["services"][0]
+    assert bpa_service["name"] == "BPA"
+    assert bpa_service["status"] == "pending"
+    assert len(bpa_service["resources"]) == 2
+
+
+def test_registration_with_single_name(
+    client_with_settings_override, mock_auth_token, mocker
+):
+    """Test registration with single name handling"""
+    data = VALID_REGISTRATION_DATA.copy()
+    data["fullname"] = "SingleName"
+
+    mock_response = MagicMock()
+    mock_response.status_code = 201
+    mock_response.json.return_value = {"user_id": "auth0|123"}
+
+    mock_post = mocker.patch("httpx.AsyncClient.post", return_value=mock_response)
+
+    response = client_with_settings_override.post("/bpa/register", json=data)
+
+    assert response.status_code == 200
+    called_data = mock_post.call_args[1]["json"]
+    assert called_data["given_name"] == "SingleName"
+    assert called_data["family_name"] == ""
+
+
+def test_registration_duplicate_user(
+    client_with_settings_override, mock_auth_token, mocker
+):
+    """Test registration with duplicate user"""
+    mock_response = MagicMock()
+    mock_response.status_code = 409
+    mocker.patch("httpx.AsyncClient.post", return_value=mock_response)
+
+    response = client_with_settings_override.post(
+        "/bpa/register", json=VALID_REGISTRATION_DATA
+    )
+
+    assert response.status_code == 409
+    assert "already exists" in response.json()["detail"]
+
+
+def test_registration_auth0_error(
+    client_with_settings_override, mock_auth_token, mocker
+):
+    """Test registration with Auth0 API error"""
+    mock_response = MagicMock()
+    mock_response.status_code = 400
+    mock_response.text = "Invalid request"
+    mocker.patch("httpx.AsyncClient.post", return_value=mock_response)
+
+    response = client_with_settings_override.post(
+        "/bpa/register", json=VALID_REGISTRATION_DATA
+    )
+
+    assert response.status_code == 400
+    assert "Failed to create user" in response.json()["detail"]
+
+
+def test_registration_with_invalid_organization(
+    client_with_settings_override, mock_auth_token, mocker
+):
+    """Test registration with invalid organization ID"""
+    data = VALID_REGISTRATION_DATA.copy()
+    data["organizations"] = {"invalid-org-id": True}
+
+    response = client_with_settings_override.post("/bpa/register", json=data)
+
+    assert response.status_code == 400
+    assert "Invalid organization ID" in response.json()["detail"]
+
+
+def test_registration_request_validation(client_with_settings_override):
+    """Test request validation"""
+    invalid_data = {
+        "username": "testuser",
+        "email": "invalid-email",
+        "organizations": {},
+    }
+
+    response = client_with_settings_override.post("/bpa/register", json=invalid_data)
+
+    assert response.status_code == 422
+
+
+def test_no_selected_organizations(
+    client_with_settings_override, mock_auth_token, mocker
+):
+    """Test registration with no organizations selected"""
+    data = VALID_REGISTRATION_DATA.copy()
+    data["organizations"] = {
+        "bpa-bioinformatics-workshop": False,
+        "cipps": False,
+        "ausarg": False,
+    }
+
+    mock_response = MagicMock()
+    mock_response.status_code = 201
+    mock_response.json.return_value = {"user_id": "auth0|123"}
+
+    mock_post = mocker.patch("httpx.AsyncClient.post", return_value=mock_response)
+
+    response = client_with_settings_override.post("/bpa/register", json=data)
+
+    assert response.status_code == 200
+    called_data = mock_post.call_args[1]["json"]
+    bpa_service = called_data["app_metadata"]["services"][0]
+    assert len(bpa_service["resources"]) == 0
+
+
+def test_empty_organizations_dict(
+    client_with_settings_override, mock_auth_token, mocker
+):
+    """Test registration with empty organizations dictionary"""
+    data = VALID_REGISTRATION_DATA.copy()
+    data["organizations"] = {}
+
+    mock_response = MagicMock()
+    mock_response.status_code = 201
+    mock_response.json.return_value = {"user_id": "auth0|123"}
+
+    mock_post = mocker.patch("httpx.AsyncClient.post", return_value=mock_response)
+
+    response = client_with_settings_override.post("/bpa/register", json=data)
+
+    assert response.status_code == 200
+    called_data = mock_post.call_args[1]["json"]
+    bpa_service = called_data["app_metadata"]["services"][0]
+    assert len(bpa_service["resources"]) == 0
+
+
+def test_registration_email_format(client_with_settings_override):
+    """Test email format validation"""
+    data = VALID_REGISTRATION_DATA.copy()
+    data["email"] = "invalid-email"
+
+    response = client_with_settings_override.post("/bpa/register", json=data)
+
+    assert response.status_code == 422
+    assert "email" in response.json()["detail"][0]["loc"]
+
+
+def test_all_organizations_selected(
+    client_with_settings_override, mock_auth_token, mocker
+):
+    """Test registration with all organizations selected"""
+    data = VALID_REGISTRATION_DATA.copy()
+    data["organizations"] = {org["id"]: True for org in Settings().organizations}
+
+    mock_response = MagicMock()
+    mock_response.status_code = 201
+    mock_response.json.return_value = {"user_id": "auth0|123"}
+
+    mock_post = mocker.patch("httpx.AsyncClient.post", return_value=mock_response)
+
+    response = client_with_settings_override.post("/bpa/register", json=data)
+
+    assert response.status_code == 200
+    called_data = mock_post.call_args[1]["json"]
+    bpa_service = called_data["app_metadata"]["services"][0]
+    assert len(bpa_service["resources"]) == len(Settings().organizations)


### PR DESCRIPTION
## Description

Add BPA registration endpoint and related tests

## Changes

- Implemented the BPA registration API endpoint with validation for user input and organization selection.
- Added settings for organizations in the configuration.
- Created comprehensive tests for successful registration, error handling, and input validation.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit / integration tests that prove my fix is effective or that my feature works
- [x] I have run all tests locally and they pass
- [x] I have updated the documentation (if applicable)

## How to Test Manually (if necessary)

Use postman or similar tools, send a post request to `localhost:8000/bpa/register` using this request body:
`{
  "username": "testuser123",
  "fullname": "Test User",
  "email": "testuser437658734567834657843@exampl3.com",
  "reason": "I need access to BPA resources for research purposes",
  "password": "TestPass123!",
  "organizations": {
    "bpa-bioinformatics-workshop": true,
    "cipps": false,
    "ausarg": true,
    "aus-avian": false,
    "aus-fish": true,
    "grasslands": false,
    "fungi": true,
    "forest-resilience": false,
    "bpa-great-barrier-reef": false,
    "bpa-ipm": false,
    "bpa-omg": false,
    "plant-pathogen": false,
    "ppa": false,
    "australian-microbiome": false,
    "threatened-species": false,
    "bpa-wheat-cultivars": false,
    "bpa-wheat-pathogens-genomes": false,
    "bpa-wheat-pathogens-transcript": false
  }
}`

Inspect the response and view the user on Auth0 Dashboard