### PR TITLE
AAI-227 add username in id token

### DIFF
--- a/auth0/client.py
+++ b/auth0/client.py
@@ -19,6 +19,13 @@ class Auth0Client:
         """Convert a list of Auth0UserResponse objects from a response."""
         return [Auth0UserResponse(**user) for user in resp.json()]
 
+    def create_user(self, user_data: dict) -> dict:
+        """Create a new user in Auth0."""
+        url = f"https://{self.domain}/api/v2/users"
+        resp = self._client.post(url, json=user_data)
+        resp.raise_for_status()
+        return resp.json()
+
     def get_users(self, page: Optional[int] = None, per_page: Optional[int] = None) -> list[Auth0UserResponse]:
         params = {}
         if page is not None:

--- a/auth0/client.py
+++ b/auth0/client.py
@@ -19,13 +19,6 @@ class Auth0Client:
         """Convert a list of Auth0UserResponse objects from a response."""
         return [Auth0UserResponse(**user) for user in resp.json()]
 
-    def create_user(self, user_data: dict) -> dict:
-        """Create a new user in Auth0."""
-        url = f"https://{self.domain}/api/v2/users"
-        resp = self._client.post(url, json=user_data)
-        resp.raise_for_status()
-        return resp.json()
-
     def get_users(self, page: Optional[int] = None, per_page: Optional[int] = None) -> list[Auth0UserResponse]:
         params = {}
         if page is not None:

--- a/routers/bpa_register.py
+++ b/routers/bpa_register.py
@@ -1,10 +1,8 @@
-import httpx
-
 from datetime import datetime, timezone
 from typing import Any, Dict
 
+import httpx
 from fastapi import APIRouter, Depends, HTTPException
-from httpx import AsyncClient
 from pydantic import BaseModel, EmailStr
 
 from auth.config import Settings, get_settings

--- a/routers/bpa_register.py
+++ b/routers/bpa_register.py
@@ -41,16 +41,21 @@ async def register_bpa_user(
     token = get_management_token(settings)
     auth0 = Auth0Client(domain=settings.auth0_domain, management_token=token)
 
-    # Create BPA resources
+    # Create BPA resources for selected organizations
     bpa_resources = []
     for org_id, is_selected in registration.organizations.items():
-        if is_selected:
-            if org_id not in settings.organizations:
-                raise HTTPException(status_code=400, detail=f"Invalid organization ID: {org_id}")
-            bpa_resources.append(
-                Resource(id=org_id, name=settings.organizations[org_id], status="pending").model_dump(mode="json")
+        if not is_selected:
+            continue
+        if org_id not in settings.organizations:
+            raise HTTPException(
+                status_code=400, detail=f"Invalid organization ID: {org_id}"
             )
+        resource = Resource(
+            id=org_id, name=settings.organizations[org_id], status="pending"
+        ).model_dump(mode="json")
+        bpa_resources.append(resource)
 
+    # Create BPA service
     bpa_service = Service(
         name="BPA",
         id="bpa",

--- a/routers/bpa_register.py
+++ b/routers/bpa_register.py
@@ -31,7 +31,6 @@ class BPARegistrationRequest(BaseModel):
         500: {"description": "Internal server error"},
     },
 )
-
 async def register_bpa_user(
     registration: BPARegistrationRequest,
     settings: Settings = Depends(get_settings),
@@ -39,8 +38,7 @@ async def register_bpa_user(
     """Register a new BPA user with selected organization resources."""
     url = f"https://{settings.auth0_domain}/api/v2/users"
     token = get_management_token(settings=settings)
-    headers = {"Authorization": f"Bearer {token}", "Content-Type":
-    "application/json"}
+    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
 
     # Create BPA resources for selected organizations
     bpa_resources = []
@@ -66,7 +64,7 @@ async def register_bpa_user(
         resources=bpa_resources,
     )
 
-    # Create Auth0 user data	    user_data = BPARegisterData.from_registration(registration, bpa_service)
+    # Create Auth0 user data
     user_data = BPARegisterData.from_registration(
         registration=registration, bpa_service=bpa_service
     )

--- a/schemas/bpa.py
+++ b/schemas/bpa.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel, EmailStr
 
 
 class BPAUserMetadata(BaseModel):
-    bpa: Dict[str, str] = {"registration_reason": ""}
+    bpa: Dict[str, str] = {"registration_reason": "", "username": ""}
 
 
 class BPAAppMetadata(BaseModel):
@@ -33,7 +33,8 @@ class BPARegisterData(BaseModel):
             username=registration.username,
             name=registration.fullname,
             user_metadata=BPAUserMetadata(
-                bpa={"registration_reason": registration.reason}
+                bpa={"registration_reason": registration.reason,
+                     "username": registration.username,},
             ),
             app_metadata=BPAAppMetadata(services=[bpa_service.model_dump(mode="json")]),
         )

--- a/tests/test_bpa_register.py
+++ b/tests/test_bpa_register.py
@@ -67,11 +67,6 @@ def test_registration_duplicate_user(test_client, mock_auth_token, mocker, valid
     mock_error = MagicMock()
     mock_error.response.json.return_value = {"message": "User already exists"}
 
-    mock_create_user = mocker.patch(
-        "routers.bpa_register.Auth0Client.create_user",
-        side_effect=Exception("Registration failed: User already exists")
-    )
-
     response = test_client.post("/bpa/register", json=valid_registration_data)
 
     assert response.status_code == 500

--- a/tests/test_bpa_register.py
+++ b/tests/test_bpa_register.py
@@ -56,11 +56,10 @@ def test_successful_registration(test_client, mock_auth_token, mocker, valid_reg
     assert "last_updated" in bpa_service
     assert len(bpa_service["resources"]) == 2
 
-    assert (
-        called_data["user_metadata"]["bpa"]["registration_reason"]
-        == valid_registration_data["reason"]
-    )
-
+    user_metadata = called_data["user_metadata"]
+    assert "bpa" in user_metadata
+    assert user_metadata["bpa"]["registration_reason"] == valid_registration_data["reason"]
+    assert user_metadata["bpa"]["username"] == valid_registration_data["username"]
 
 def test_registration_duplicate_user(test_client, mock_auth_token, mocker, valid_registration_data):
     """Test registration with duplicate user"""

--- a/tests/test_bpa_register.py
+++ b/tests/test_bpa_register.py
@@ -30,24 +30,19 @@ def mock_auth_token(mocker):
     return token
 
 
-def test_successful_registration(
-        test_client, mock_auth_token, mocker, valid_registration_data
-):
+def test_successful_registration(test_client, mock_auth_token, mocker, valid_registration_data):
     """Test successful user registration with BPA service"""
-    mock_response = MagicMock()
-    mock_response.status_code = 201
-    mock_response.json.return_value = {"user_id": "auth0|123"}
+    mock_response = {"user_id": "auth0|123"}
 
-    mock_post = mocker.patch("httpx.AsyncClient.post", return_value=mock_response)
+    mock_create_user = mocker.patch("routers.bpa_register.Auth0Client.create_user", return_value=mock_response)
 
-    response = test_client.post(
-        "/bpa/register", json=valid_registration_data
-    )
+    response = test_client.post("/bpa/register", json=valid_registration_data)
 
     assert response.status_code == 200
     assert response.json()["message"] == "User registered successfully"
+    assert response.json()["user"] == mock_response
 
-    called_data = mock_post.call_args[1]["json"]
+    called_data = mock_create_user.call_args[0][0]  # first positional argument to create_user
     assert called_data["email"] == valid_registration_data["email"]
     assert called_data["username"] == valid_registration_data["username"]
     assert called_data["name"] == valid_registration_data["fullname"]
@@ -57,6 +52,8 @@ def test_successful_registration(
     bpa_service = app_metadata["services"][0]
     assert bpa_service["name"] == "BPA"
     assert bpa_service["status"] == "pending"
+    assert bpa_service["updated_by"] == "system"
+    assert "last_updated" in bpa_service
     assert len(bpa_service["resources"]) == 2
 
     assert (
@@ -65,45 +62,23 @@ def test_successful_registration(
     )
 
 
-def test_registration_duplicate_user(
-        test_client, mock_auth_token, mocker, valid_registration_data
-):
+def test_registration_duplicate_user(test_client, mock_auth_token, mocker, valid_registration_data):
     """Test registration with duplicate user"""
-    mock_response = MagicMock()
-    mock_response.status_code = 409
-    mock_response.json.return_value = {"message": "User already exists"}
+    mock_error = MagicMock()
+    mock_error.response.json.return_value = {"message": "User already exists"}
 
-    mocker.patch("httpx.AsyncClient.post", return_value=mock_response)
-
-    response = test_client.post(
-        "/bpa/register", json=valid_registration_data
+    mock_create_user = mocker.patch(
+        "routers.bpa_register.Auth0Client.create_user",
+        side_effect=Exception("Registration failed: User already exists")
     )
 
-    assert response.status_code == 400
-    assert response.json()["detail"] == "Registration failed: User already exists"
+    response = test_client.post("/bpa/register", json=valid_registration_data)
+
+    assert response.status_code == 500
+    assert "Failed to register user" in response.json()["detail"]
 
 
-def test_registration_auth0_error(
-        test_client, mock_auth_token, mocker, valid_registration_data
-):
-    """Test registration with Auth0 API error"""
-    mock_response = MagicMock()
-    mock_response.status_code = 400
-    mock_response.json.return_value = {"message": "Invalid request"}
-
-    mocker.patch("httpx.AsyncClient.post", return_value=mock_response)
-
-    response = test_client.post(
-        "/bpa/register", json=valid_registration_data
-    )
-
-    assert response.status_code == 400
-    assert response.json()["detail"] == "Registration failed: Invalid request"
-
-
-def test_registration_with_invalid_organization(
-        test_client, mock_auth_token, mocker, valid_registration_data
-):
+def test_registration_with_invalid_organization(test_client, mock_auth_token, valid_registration_data):
     """Test registration with invalid organization ID"""
     data = valid_registration_data.copy()
     data["organizations"] = {"invalid-org-id": True}
@@ -127,9 +102,7 @@ def test_registration_request_validation(test_client):
     assert response.status_code == 422
 
 
-def test_no_selected_organizations(
-        test_client, mock_auth_token, mocker, valid_registration_data
-):
+def test_no_selected_organizations(test_client, mock_auth_token, mocker, valid_registration_data):
     """Test registration with no organizations selected"""
     data = valid_registration_data.copy()
     data["organizations"] = {
@@ -138,44 +111,32 @@ def test_no_selected_organizations(
         "ausarg": False,
     }
 
-    mock_response = MagicMock()
-    mock_response.status_code = 201
-    mock_response.json.return_value = {"user_id": "auth0|123"}
-
-    mock_post = mocker.patch("httpx.AsyncClient.post", return_value=mock_response)
+    mock_create_user = mocker.patch("routers.bpa_register.Auth0Client.create_user", return_value={"user_id": "auth0|123"})
 
     response = test_client.post("/bpa/register", json=data)
 
     assert response.status_code == 200
-    called_data = mock_post.call_args[1]["json"]
+    called_data = mock_create_user.call_args[0][0]
     bpa_service = called_data["app_metadata"]["services"][0]
     assert len(bpa_service["resources"]) == 0
 
 
-def test_empty_organizations_dict(
-        test_client, mock_auth_token, mocker, valid_registration_data
-):
+def test_empty_organizations_dict(test_client, mock_auth_token, mocker, valid_registration_data):
     """Test registration with empty organizations dictionary"""
     data = valid_registration_data.copy()
     data["organizations"] = {}
 
-    mock_response = MagicMock()
-    mock_response.status_code = 201
-    mock_response.json.return_value = {"user_id": "auth0|123"}
-
-    mock_post = mocker.patch("httpx.AsyncClient.post", return_value=mock_response)
+    mock_create_user = mocker.patch("routers.bpa_register.Auth0Client.create_user", return_value={"user_id": "auth0|123"})
 
     response = test_client.post("/bpa/register", json=data)
 
     assert response.status_code == 200
-    called_data = mock_post.call_args[1]["json"]
+    called_data = mock_create_user.call_args[0][0]
     bpa_service = called_data["app_metadata"]["services"][0]
     assert len(bpa_service["resources"]) == 0
 
 
-def test_registration_email_format(
-        test_client, valid_registration_data
-):
+def test_registration_email_format(test_client, valid_registration_data):
     """Test email format validation"""
     data = valid_registration_data.copy()
     data["email"] = "invalid-email"
@@ -186,26 +147,16 @@ def test_registration_email_format(
     assert "email" in response.json()["detail"][0]["loc"]
 
 
-def test_all_organizations_selected(
-        test_client,
-    mock_auth_token,
-    mock_settings,
-    mocker,
-    valid_registration_data,
-):
+def test_all_organizations_selected(test_client, mock_auth_token, mock_settings, mocker, valid_registration_data):
     """Test registration with all organizations selected"""
     data = valid_registration_data.copy()
     data["organizations"] = {k: True for k in mock_settings.organizations.keys()}
 
-    mock_response = MagicMock()
-    mock_response.status_code = 201
-    mock_response.json.return_value = {"user_id": "auth0|123"}
-
-    mock_post = mocker.patch("httpx.AsyncClient.post", return_value=mock_response)
+    mock_create_user = mocker.patch("routers.bpa_register.Auth0Client.create_user", return_value={"user_id": "auth0|123"})
 
     response = test_client.post("/bpa/register", json=data)
 
     assert response.status_code == 200
-    called_data = mock_post.call_args[1]["json"]
+    called_data = mock_create_user.call_args[0][0]
     bpa_service = called_data["app_metadata"]["services"][0]
     assert len(bpa_service["resources"]) == len(mock_settings.organizations)


### PR DESCRIPTION
## Description

[AAI-227](https://biocloud.atlassian.net/browse/AAI-227): Add username obtained from BPA registration process to Auth0 ID token.

## Changes

- Add `username` field to the user_metadata during registration
- Update token generation logic to include username (in [Auth0 post login `BPA:USER_DATA` action](https://manage.auth0.com/dashboard/au/dev-bc/actions/library/details/05747705-5762-42d5-a153-fc7adb653295))
- Modifies tests to verify username is present in the user_metadata


## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit / integration tests that prove my fix is effective or that my feature works
- [x] I have run all tests locally and they pass
- [x] I have updated the documentation (if applicable)

## How to Test Manually (if necessary)

All unit tests on Github actions shall pass


[AAI-227]: https://biocloud.atlassian.net/browse/AAI-227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ