### PR TITLE
AAI-236 Bugfix for datetimes in JSON

### DIFF
--- a/routers/bpa_register.py
+++ b/routers/bpa_register.py
@@ -62,7 +62,7 @@ async def register_bpa_user(
     try:
         async with AsyncClient() as client:
             response = await client.post(
-                url, headers=headers, json=user_data.model_dump()
+                url, headers=headers, json=user_data.model_dump(mode="json")
             )
             if response.status_code != 201:
                 raise HTTPException(

--- a/routers/galaxy_register.py
+++ b/routers/galaxy_register.py
@@ -41,7 +41,7 @@ def register(
     headers = {"Authorization": f"Bearer {management_token}"}
     user_data = BiocommonsRegisterData.from_galaxy_registration(registration_data)
     logger.debug("Registering with Auth0 management API")
-    resp = httpx.post(url, json=user_data.model_dump(), headers=headers)
+    resp = httpx.post(url, json=user_data.model_dump(mode="json"), headers=headers)
     if resp.status_code != 201:
         raise HTTPException(status_code=400, detail=f'Registration failed: {resp.json()["message"]}')
     return {"message": "User registered successfully", "user": resp.json()}

--- a/routers/user.py
+++ b/routers/user.py
@@ -162,7 +162,7 @@ async def request_service(
     await update_user_metadata(
         user.access_token.sub,
         get_management_token(settings=settings),
-        user_data.app_metadata.model_dump(),
+        user_data.app_metadata.model_dump(mode="json"),
     )
 
     return {
@@ -231,7 +231,7 @@ async def request_resource(
     await update_user_metadata(
         user.access_token.sub,
         get_management_token(settings=settings),
-        user_data.app_metadata.model_dump(),
+        user_data.app_metadata.model_dump(mode="json"),
     )
 
     return {


### PR DESCRIPTION
## Description

[AAI-236](https://biocloud.atlassian.net/browse/AAI-236): currently getting an error "datetime is not JSON-serializable" when trying to register on Galaxy. Caused by not converting to JSON-friendly types before putting things in POST requests etc.

## Changes

- Make sure we use `model_dump(mode='json')` before sending POST data to Auth0
- Tests for handling of types like `datetime`

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit / integration tests that prove my fix is effective or that my feature works
- [x] I have run all tests locally and they pass
- [x] I have updated the documentation (if applicable)

## How to Test Manually (if necessary)

Run `uv run pytest`


[AAI-236]: https://biocloud.atlassian.net/browse/AAI-236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ