### PR TITLE
AAI-236 Exclude empty fields when posting registration data to Auth0 API

### DIFF
--- a/routers/galaxy_register.py
+++ b/routers/galaxy_register.py
@@ -41,7 +41,16 @@ def register(
     headers = {"Authorization": f"Bearer {management_token}"}
     user_data = BiocommonsRegisterData.from_galaxy_registration(registration_data)
     logger.debug("Registering with Auth0 management API")
-    resp = httpx.post(url, json=user_data.model_dump(mode="json"), headers=headers)
+    resp = httpx.post(
+        url,
+        # Use exclude_none so we don't include username/name fields
+        #   when not specified, Auth0 doesn't like this
+        json=user_data.model_dump(
+            mode="json",
+            exclude_none=True
+        ),
+        headers=headers
+    )
     if resp.status_code != 201:
         raise HTTPException(status_code=400, detail=f'Registration failed: {resp.json()["message"]}')
     return {"message": "User registered successfully", "user": resp.json()}

--- a/tests/test_galaxy.py
+++ b/tests/test_galaxy.py
@@ -85,6 +85,25 @@ def test_to_biocommons_register_data():
     assert auth0_data.user_metadata.galaxy_username == "valid_username"
 
 
+def test_to_biocommons_register_data_empty_fields():
+    """
+    Test 'username' and 'name' are left out of dumped data,
+    since we don't use these in Galaxy registration,
+    and the Auth0 API doesn't like them being included
+    """
+    data = GalaxyRegistrationData(
+        email="user@example.com",
+        password="securepassword",
+        password_confirmation="securepassword",
+        public_name="valid_username"
+    )
+
+    auth0_data = BiocommonsRegisterData.from_galaxy_registration(data)
+    dumped = auth0_data.model_dump(mode="json", exclude_none=True)
+    assert "username" not in dumped
+    assert "name" not in dumped
+
+
 @freeze_time("2025-01-01")
 def test_register(mocker, mock_auth_token, mock_settings, test_client):
     """
@@ -112,7 +131,7 @@ def test_register(mocker, mock_auth_token, mock_settings, test_client):
     register_data = BiocommonsRegisterData.from_galaxy_registration(user_data)
     mock_post.assert_called_once_with(
         url,
-        json=register_data.model_dump(mode="json"),
+        json=register_data.model_dump(mode="json", exclude_none=True),
         headers=headers
     )
 


### PR DESCRIPTION
## Description

[AAI-236](https://biocloud.atlassian.net/browse/AAI-236): another small fix encountered when running against the actual Auth0 API: the API doesn't like empty fields being sent as null/None, even if the fields are optional - exclude these fields when posting data

## Changes

- Use `exclude_none=True` so `None` fields are not included in posted data

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit / integration tests that prove my fix is effective or that my feature works
- [x] I have run all tests locally and they pass
- [x] I have updated the documentation (if applicable)

## How to Test Manually (if necessary)

Run `uv run pytest`


[AAI-236]: https://biocloud.atlassian.net/browse/AAI-236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ