### PR TITLE
AAI-223 Add a 'registration_from' field to app_metadata so we can show app-specific email verification

### DIFF
--- a/schemas/biocommons.py
+++ b/schemas/biocommons.py
@@ -5,7 +5,7 @@ These are the core schemas we use for storing/representing users
 and their metadata
 """
 from datetime import datetime
-from typing import List, Optional, Self
+from typing import List, Literal, Optional, Self
 
 from pydantic import BaseModel, EmailStr, Field, HttpUrl
 
@@ -13,6 +13,8 @@ from schemas import Resource, Service
 from schemas.bpa import BPARegistrationRequest
 from schemas.galaxy import GalaxyRegistrationData
 from schemas.service import Group, Identity
+
+AppId = Literal["biocommons", "galaxy", "bpa"]
 
 
 class BPAMetadata(BaseModel):
@@ -37,6 +39,7 @@ class BiocommonsAppMetadata(BaseModel):
     """
     groups: List[Group] = Field(default_factory=list)
     services: List[Service] = Field(default_factory=list)
+    signup_from: Optional[AppId] = None
 
     def get_pending_services(self) -> List[Service]:
         """Get all pending services."""

--- a/schemas/biocommons.py
+++ b/schemas/biocommons.py
@@ -39,7 +39,7 @@ class BiocommonsAppMetadata(BaseModel):
     """
     groups: List[Group] = Field(default_factory=list)
     services: List[Service] = Field(default_factory=list)
-    signup_from: Optional[AppId] = None
+    registration_from: Optional[AppId] = None
 
     def get_pending_services(self) -> List[Service]:
         """Get all pending services."""
@@ -124,7 +124,7 @@ class BiocommonsRegisterData(BaseModel):
             ),
             app_metadata=BiocommonsAppMetadata(
                 services=[bpa_service],
-                signup_from="bpa"
+                registration_from="bpa"
             ),
         )
 
@@ -148,7 +148,7 @@ class BiocommonsRegisterData(BaseModel):
             connection="Username-Password-Authentication",
             app_metadata=BiocommonsAppMetadata(
                 services=[galaxy_service],
-                signup_from='galaxy'
+                registration_from='galaxy'
             ),
         )
 

--- a/schemas/biocommons.py
+++ b/schemas/biocommons.py
@@ -122,7 +122,10 @@ class BiocommonsRegisterData(BaseModel):
                 bpa=BPAMetadata(registration_reason=registration.reason,
                                 username=registration.username,),
             ),
-            app_metadata=BiocommonsAppMetadata(services=[bpa_service]),
+            app_metadata=BiocommonsAppMetadata(
+                services=[bpa_service],
+                signup_from="bpa"
+            ),
         )
 
     @classmethod
@@ -143,7 +146,10 @@ class BiocommonsRegisterData(BaseModel):
             password=registration.password,
             email_verified=False,
             connection="Username-Password-Authentication",
-            app_metadata=BiocommonsAppMetadata(services=[galaxy_service]),
+            app_metadata=BiocommonsAppMetadata(
+                services=[galaxy_service],
+                signup_from='galaxy'
+            ),
         )
 
 

--- a/tests/test_bpa_register.py
+++ b/tests/test_bpa_register.py
@@ -1,7 +1,10 @@
+from datetime import UTC, datetime
 from unittest.mock import MagicMock
 
 import pytest
 
+from schemas import Service
+from schemas.biocommons import BiocommonsRegisterData
 from tests.datagen import AccessTokenPayloadFactory, BPARegistrationDataFactory
 
 
@@ -28,6 +31,25 @@ def mock_auth_token(mocker):
     mocker.patch("auth.management.get_management_token", return_value="mock_token")
     mocker.patch("routers.bpa_register.get_management_token", return_value="mock_token")
     return token
+
+
+def test_to_biocommons_register_data(valid_registration_data):
+    bpa_data = BPARegistrationDataFactory.build()
+    bpa_service = Service(
+        name="Bioplatforms Australia",
+        id="bpa",
+        status="approved",
+        last_updated=datetime.now(UTC),
+        updated_by=''
+    )
+    register_data = BiocommonsRegisterData.from_bpa_registration(
+        bpa_data,
+        bpa_service=bpa_service
+    )
+    assert register_data.username == bpa_data.username
+    assert register_data.name == bpa_data.fullname
+    # Test we fill the signup_from field in app_metadata
+    assert register_data.app_metadata.signup_from == "bpa"
 
 
 def test_successful_registration(

--- a/tests/test_bpa_register.py
+++ b/tests/test_bpa_register.py
@@ -48,8 +48,8 @@ def test_to_biocommons_register_data(valid_registration_data):
     )
     assert register_data.username == bpa_data.username
     assert register_data.name == bpa_data.fullname
-    # Test we fill the signup_from field in app_metadata
-    assert register_data.app_metadata.signup_from == "bpa"
+    # Test we fill the registration_from field in app_metadata
+    assert register_data.app_metadata.registration_from == "bpa"
 
 
 def test_successful_registration(

--- a/tests/test_galaxy.py
+++ b/tests/test_galaxy.py
@@ -83,7 +83,7 @@ def test_to_biocommons_register_data():
     assert auth0_data.connection == "Username-Password-Authentication"
     assert not auth0_data.email_verified
     assert auth0_data.user_metadata.galaxy_username == "valid_username"
-    assert auth0_data.app_metadata.signup_from == "galaxy"
+    assert auth0_data.app_metadata.registration_from == "galaxy"
 
 
 @freeze_time("2025-01-01")

--- a/tests/test_galaxy.py
+++ b/tests/test_galaxy.py
@@ -83,6 +83,7 @@ def test_to_biocommons_register_data():
     assert auth0_data.connection == "Username-Password-Authentication"
     assert not auth0_data.email_verified
     assert auth0_data.user_metadata.galaxy_username == "valid_username"
+    assert auth0_data.app_metadata.signup_from == "galaxy"
 
 
 @freeze_time("2025-01-01")


### PR DESCRIPTION
## Description

[AAI-223](https://biocloud.atlassian.net/browse/AAI-223): We need a way to let Auth0 know which app the user signed up from, so we can show app-specific info on email verification pages. Adding a field to app_metadata seems like a good way to do this

## Changes

- Add registration_from to app_metadata schema
- Add it when creating registration data for each app
- Tests

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit / integration tests that prove my fix is effective or that my feature works
- [x] I have run all tests locally and they pass
- [x] I have updated the documentation (if applicable)

## How to Test Manually (if necessary)

Run `uv run pytest`


[AAI-223]: https://biocloud.atlassian.net/browse/AAI-223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ