### PR TITLE
AAI-223 add an endpoint to get registration info based on user's email address

### DIFF
--- a/auth0/client.py
+++ b/auth0/client.py
@@ -3,7 +3,10 @@ __all__ = ["Auth0Client"]
 from typing import Optional
 
 import httpx
+from fastapi import Depends
 
+from auth.config import Settings, get_settings
+from auth.management import get_management_token
 from schemas.biocommons import BiocommonsAuth0User
 
 
@@ -75,3 +78,8 @@ class Auth0Client:
     def get_revoked_users(self, page: Optional[int] = None, per_page: Optional[int] = None) -> list[BiocommonsAuth0User]:
         revoked_query = 'app_metadata.services.status:"revoked"'
         return self._search_users(revoked_query, page, per_page)
+
+
+def get_auth0_client(settings: Settings = Depends(get_settings),
+                     management_token: str = Depends(get_management_token)):
+    return Auth0Client(settings.auth0_domain, management_token=management_token)

--- a/auth0/client.py
+++ b/auth0/client.py
@@ -36,6 +36,11 @@ class Auth0Client:
         resp = self._client.get(url)
         return BiocommonsAuth0User(**resp.json())
 
+    def search_users_by_email(self, email: str) -> list[BiocommonsAuth0User]:
+        url = f"https://{self.domain}/api/v2/users-by-email"
+        resp = self._client.get(url, params={"email": email})
+        return self._convert_users(resp)
+
     def _search_users(self, query: str, page: Optional[int] = None, per_page: Optional[int] = None) -> list[BiocommonsAuth0User]:
         params = {"q": query, "search_engine": "v3"}
         if page is not None:

--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@ from dotenv import dotenv_values
 from fastapi import FastAPI
 from starlette.middleware.cors import CORSMiddleware
 
-from routers import admin, bpa_register, galaxy_register, user
+from routers import admin, bpa_register, galaxy_register, user, utils
 
 # Load .env to get CORS_ALLOWED_ORIGINS.
 # Note that for most env variables, we use pydantic-settings
@@ -33,3 +33,4 @@ app.include_router(admin.router)
 app.include_router(user.router)
 app.include_router(bpa_register.router)
 app.include_router(galaxy_register.router)
+app.include_router(utils.router)

--- a/routers/admin.py
+++ b/routers/admin.py
@@ -6,10 +6,8 @@ from fastapi import APIRouter, Depends, HTTPException, Path
 from fastapi.params import Query
 from pydantic import BaseModel, ValidationError
 
-from auth.config import Settings, get_settings
-from auth.management import get_management_token
 from auth.validator import get_current_user, user_is_admin
-from auth0.client import Auth0Client
+from auth0.client import Auth0Client, get_auth0_client
 from routers.user import update_user_metadata
 from schemas.biocommons import BiocommonsAuth0User
 from schemas.user import SessionUser
@@ -46,11 +44,6 @@ def get_pagination_params(page: int = 1, per_page: int = 100):
 
 router = APIRouter(prefix="/admin", tags=["admin"],
                    dependencies=[Depends(user_is_admin)])
-
-
-def get_auth0_client(settings: Settings = Depends(get_settings),
-                     management_token: str = Depends(get_management_token)):
-    return Auth0Client(settings.auth0_domain, management_token=management_token)
 
 
 @router.get("/users",

--- a/routers/utils.py
+++ b/routers/utils.py
@@ -1,0 +1,31 @@
+from typing import Annotated
+
+from fastapi import APIRouter
+from fastapi.params import Depends
+from pydantic import BaseModel
+
+from auth0.client import Auth0Client, get_auth0_client
+from schemas.biocommons import AppId
+
+router = APIRouter(prefix="/utils", tags=["utils"])
+
+
+class RegistrationInfo(BaseModel):
+    app: AppId = "biocommons"
+
+
+@router.get("/registration_info")
+async def get_registration_info(
+        user_email: str,
+        client: Annotated[Auth0Client, Depends(get_auth0_client)]):
+    """
+    Return the app a user used to sign up, if available in app_metadata.
+    """
+    results = client.search_users_by_email(email=user_email)
+    for user in results:
+        current_email = str(user.email).lower()
+        if current_email == user_email.lower():
+            if user.app_metadata.registration_from is None:
+                return RegistrationInfo(app="biocommons")
+            return RegistrationInfo(app=user.app_metadata.registration_from)
+    return RegistrationInfo(app="biocommons")

--- a/routers/utils.py
+++ b/routers/utils.py
@@ -19,7 +19,7 @@ async def get_registration_info(
         user_email: str,
         client: Annotated[Auth0Client, Depends(get_auth0_client)]):
     """
-    Return the app a user used to sign up, if available in app_metadata.
+    Return the app a user used to register, if available in app_metadata.
     """
     results = client.search_users_by_email(email=user_email)
     for user in results:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,58 @@
+import pytest
+
+from auth0.client import get_auth0_client
+from main import app
+from tests.datagen import AppMetadataFactory, BiocommonsAuth0UserFactory
+
+
+@pytest.fixture
+def override_auth0_client(mocker):
+    def override_auth0_client():
+        return mock_client
+
+    mock_client = mocker.patch("routers.utils.Auth0Client")()
+    app.dependency_overrides[get_auth0_client] = override_auth0_client
+    yield mock_client
+    app.dependency_overrides.clear()
+
+
+def test_get_registration_info(override_auth0_client, test_client):
+    """
+    Test we can look up a user by email, and return their
+    app_metadata.registration_from value, if available.
+    """
+    app_metadata = AppMetadataFactory.build(registration_from="galaxy")
+    user = BiocommonsAuth0UserFactory.build(email="user@example.com",
+                                            app_metadata=app_metadata)
+    override_auth0_client.search_users_by_email.return_value = [user]
+    resp = test_client.get("/utils/registration_info", params={"user_email": user.email})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["app"] == "galaxy"
+
+
+def test_get_registration_info_no_registration_from(override_auth0_client, test_client):
+    """
+    Test the default of 'biocommons' is returned if registration_from isn't set.
+    """
+    app_metadata = AppMetadataFactory.build(registration_from=None)
+    user = BiocommonsAuth0UserFactory.build(email="user@example.com",
+                                            app_metadata=app_metadata)
+    override_auth0_client.search_users_by_email.return_value = [user]
+    resp = test_client.get("/utils/registration_info", params={"user_email": user.email})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["app"] == "biocommons"
+
+
+def test_get_registration_info_no_user(override_auth0_client, test_client):
+    """
+    Test the default of 'biocommons' is returned if the user doesn't exist.
+    (we don't want an endpoint that allows easily checking if a user
+    exists or not)
+    """
+    override_auth0_client.search_users_by_email.return_value = []
+    resp = test_client.get("/utils/registration_info", params={"user_email": "notfound@example.com"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["app"] == "biocommons"


### PR DESCRIPTION
## Description

[AAI-223](https://biocloud.atlassian.net/browse/AAI-223): there doesn't seem to be a good way to pass the registration info from Auth0 directly to our registration page. Instead, if we want to have app-specific email verification pages (and go directly from them to app login), it looks like we have to:

- Pass the email from Auth0 to the verification page (Auth0 allows this, although it's not well documented)
- Do a lookup from the frontend verification page - call this new API to get the registration source (if it's available)

## TODO:

* Document how we pass email from Auth0 to the verification page - requires using the management API to change a setting

## Possible issues

- Are there privacy/security concerns around having an endpoint that (theoretically) allows you to check whether a user exists in the system based on email address? Have tried to minimize the amount of info returned, but if the response is anything other than the default of "biocommons", you would know the user is in the system

## Changes

- Add `/utils/registration_info?user_email=user@example.com` endpoint
- Look up user by email in the management API

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit / integration tests that prove my fix is effective or that my feature works
- [x] I have run all tests locally and they pass
- [x] I have updated the documentation (if applicable)

## How to Test Manually (if necessary)

Run `uv run pytest`


[AAI-223]: https://biocloud.atlassian.net/browse/AAI-223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ