### PR TITLE
AAI-119 Fix: Set AWS_DB_SECRET in deploy action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,6 +56,7 @@ jobs:
           AWS_ZONE_ID=${{ secrets.AWS_ZONE_ID }}
           AWS_ZONE_DOMAIN=${{ secrets.AWS_ZONE_DOMAIN }}
           AWS_DB_HOST=${{ secrets.AWS_DB_HOST }}
+          AWS_DB_SECRET=${{ secrets.AWS_DB_SECRET }}
           EOF
 
       - name: CDK Deploy


### PR DESCRIPTION
Quick fix for a secret not being passed through to the GitHub Action that does deployment
