### PR TITLE
AAI-281 GUI admin for the backend database (refreshed to clean up the diff)

### DIFF
--- a/db/admin.py
+++ b/db/admin.py
@@ -10,7 +10,7 @@ from starlette.responses import RedirectResponse, Response
 
 from auth.validator import verify_jwt
 from config import get_settings
-from db.models import Auth0Role, BiocommonsGroup
+from db.models import ApprovalHistory, Auth0Role, BiocommonsGroup, GroupMembership
 from db.setup import engine
 
 
@@ -59,6 +59,29 @@ class AdminAuth(AuthenticationBackend):
         return False
 
 
+class GroupAdmin(ModelView, model=BiocommonsGroup):
+    can_edit = False
+    can_create = False
+
+
+class Auth0RoleAdmin(ModelView, model=Auth0Role):
+    can_edit = False
+    can_create = False
+    column_list = ["id", "name", "description"]
+
+
+class GroupMembershipAdmin(ModelView, model=GroupMembership):
+    can_edit = False
+    can_create = False
+    column_list = ["name", "group_id", "user_email", "user_id", "approval_status", "updated_at", "updated_by_email"]
+
+
+class ApprovalHistoryAdmin(ModelView, model=ApprovalHistory):
+    can_edit = False
+    can_create = False
+    column_list = ["name", "group_id", "user_email", "user_id", "approval_status", "updated_at", "updated_by_email"]
+
+
 class DatabaseAdmin:
 
     def __init__(self, app: FastAPI, session_middleware: Middleware):
@@ -93,14 +116,3 @@ class DatabaseAdmin:
             raise HTTPException(status_code=401, detail="User does not have admin role.")
         request.session['biocommons_roles'] = payload.biocommons_roles
         return RedirectResponse(request.url_for("admin:index"), status_code=302)
-
-
-class GroupAdmin(ModelView, model=BiocommonsGroup):
-    can_edit = False
-    can_create = False
-
-
-class Auth0RoleAdmin(ModelView, model=Auth0Role):
-    can_edit = False
-    can_create = False
-    column_list = ["id", "name", "description"]

--- a/db/admin.py
+++ b/db/admin.py
@@ -62,17 +62,20 @@ class AdminAuth(AuthenticationBackend):
 class GroupAdmin(ModelView, model=BiocommonsGroup):
     can_edit = False
     can_create = False
+    can_delete = False
 
 
 class Auth0RoleAdmin(ModelView, model=Auth0Role):
     can_edit = False
     can_create = False
+    can_delete = False
     column_list = ["id", "name", "description"]
 
 
 class GroupMembershipAdmin(ModelView, model=GroupMembership):
     can_edit = False
     can_create = False
+    can_delete = False
     column_list = ["name", "group_id", "user_email", "user_id", "approval_status", "updated_at", "updated_by_email"]
     column_filters = [
         AllUniqueStringValuesFilter(GroupMembership.group_id),
@@ -83,6 +86,7 @@ class GroupMembershipAdmin(ModelView, model=GroupMembership):
 class ApprovalHistoryAdmin(ModelView, model=ApprovalHistory):
     can_edit = False
     can_create = False
+    can_delete = False
     column_list = ["name", "group_id", "user_email", "user_id", "approval_status", "updated_at", "updated_by_email"]
 
 

--- a/db/admin.py
+++ b/db/admin.py
@@ -1,0 +1,89 @@
+from typing import Self, Union
+
+from authlib.integrations.starlette_client import OAuth
+from fastapi import FastAPI
+from sqladmin import Admin, ModelView
+from sqladmin.authentication import AuthenticationBackend
+from starlette.requests import Request
+from starlette.responses import RedirectResponse, Response
+
+from config import get_settings
+from db.models import Auth0Role, BiocommonsGroup
+from db.setup import engine
+
+
+def setup_oauth():
+    settings = get_settings()
+    oauth = OAuth()
+    oauth.register(
+        name="auth0",
+        client_id=settings.auth0_management_id,
+        client_secret=settings.auth0_management_secret,
+        api_base_url=f"https://{settings.auth0_domain}",
+        access_token_url=f"https://{settings.auth0_domain}/oauth/token",
+        authorize_url=f"https://{settings.auth0_domain}/authorize",
+        server_metadata_url=f'https://{settings.auth0_domain}/.well-known/openid-configuration',
+        client_kwargs={
+            "scope": "openid profile email",
+        }
+    )
+    return oauth.create_client("auth0")
+
+
+class AdminAuth(AuthenticationBackend):
+    async def login(self, request: Request) -> bool:
+        return True
+
+    async def logout(self, request: Request) -> bool:
+        request.session.clear()
+        return True
+
+    async def authenticate(self, request: Request) -> Union[bool, RedirectResponse]:
+        user = request.session.get("user")
+        if not user:
+            redirect_uri = request.url_for('login_auth0')
+            return await auth0_client.authorize_redirect(request, redirect_uri)
+
+        return True
+
+
+class DatabaseAdmin:
+
+    def __init__(self, app: FastAPI, secret_key: str):
+        self.app = app
+        self.admin = Admin(
+            app,
+            engine=engine,
+            base_url="/db_admin",
+            authentication_backend=AdminAuth(secret_key=secret_key),
+            title="AAI Backend Admin"
+        )
+
+    @classmethod
+    def setup(cls, app: FastAPI, secret_key: str) -> Self:
+        db_admin = cls(app, secret_key)
+        db_admin.admin.add_view(GroupAdmin)
+        db_admin.admin.add_view(Auth0RoleAdmin)
+        db_admin.admin.app.router.add_route("/auth/auth0", login_auth0)
+        return db_admin
+
+
+class GroupAdmin(ModelView, model=BiocommonsGroup):
+    can_edit = False
+    can_create = False
+
+
+class Auth0RoleAdmin(ModelView, model=Auth0Role):
+    can_edit = False
+    can_create = False
+    column_list = ["id", "name", "description"]
+
+
+async def login_auth0(request: Request) -> Response:
+    token = await auth0_client.authorize_access_token(request)
+    user = token.get('userinfo')
+    if user:
+        request.session['user'] = user
+    return RedirectResponse(request.url_for("admin:index"))
+
+auth0_client = setup_oauth()

--- a/db/admin.py
+++ b/db/admin.py
@@ -15,6 +15,9 @@ from db.setup import engine
 
 
 def setup_oauth():
+    """
+    Set up an OAuth client for Auth0.
+    """
     settings = get_settings()
     oauth = OAuth()
     oauth.register(
@@ -34,6 +37,10 @@ def setup_oauth():
 
 
 class AdminAuth(AuthenticationBackend):
+    """
+    Authentication backend for the Admin app.
+    Checks that the user has an admin role before allowing access.
+    """
 
     def __init__(self, secret_key: str, auth0_client: OAuth):
         super().__init__(secret_key=secret_key)
@@ -92,6 +99,9 @@ class ApprovalHistoryAdmin(ModelView, model=ApprovalHistory):
 
 
 class DatabaseAdmin:
+    """
+    Sets up the Admin app for the database.
+    """
     views = (GroupAdmin, Auth0RoleAdmin, GroupMembershipAdmin, ApprovalHistoryAdmin,)
 
     def __init__(self, app: FastAPI, secret_key: str):

--- a/db/admin.py
+++ b/db/admin.py
@@ -1,12 +1,14 @@
 from typing import Self, Union
 
 from authlib.integrations.starlette_client import OAuth
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from sqladmin import Admin, ModelView
 from sqladmin.authentication import AuthenticationBackend
+from starlette.middleware import Middleware
 from starlette.requests import Request
 from starlette.responses import RedirectResponse, Response
 
+from auth.validator import verify_jwt
 from config import get_settings
 from db.models import Auth0Role, BiocommonsGroup
 from db.setup import engine
@@ -25,14 +27,16 @@ def setup_oauth():
         server_metadata_url=f'https://{settings.auth0_domain}/.well-known/openid-configuration',
         client_kwargs={
             "scope": "openid profile email",
+            "audience": settings.auth0_audience
         }
     )
     return oauth.create_client("auth0")
 
 
 class AdminAuth(AuthenticationBackend):
-    def __init__(self, secret_key: str, auth0_client: OAuth):
-        super().__init__(secret_key=secret_key)
+
+    def __init__(self, session_middleware: Middleware, auth0_client: OAuth):
+        self.middlewares = [session_middleware]
         self.auth0_client = auth0_client
 
     async def login(self, request: Request) -> bool:
@@ -43,41 +47,52 @@ class AdminAuth(AuthenticationBackend):
         return True
 
     async def authenticate(self, request: Request) -> Union[bool, RedirectResponse]:
-        user = request.session.get("user")
-        if not user:
+        settings = get_settings()
+        roles = request.session.get("biocommons_roles")
+        if not roles:
+            print("Redirecting to Auth0 for login.")
             redirect_uri = request.url_for('login_auth0')
             return await self.auth0_client.authorize_redirect(request, redirect_uri)
-
-        return True
+        for role in roles:
+            if role in settings.admin_roles:
+                return True
+        return False
 
 
 class DatabaseAdmin:
 
-    def __init__(self, app: FastAPI, secret_key: str):
+    def __init__(self, app: FastAPI, session_middleware: Middleware):
         self.app = app
         self.auth0_client = setup_oauth()
         self.admin = Admin(
             app,
             engine=engine,
             base_url="/db_admin",
-            authentication_backend=AdminAuth(secret_key=secret_key, auth0_client=self.auth0_client),
+            authentication_backend=AdminAuth(session_middleware=session_middleware, auth0_client=self.auth0_client),
             title="AAI Backend Admin"
         )
         self.admin.app.router.add_route("/auth/auth0", self.login_auth0)
 
     @classmethod
-    def setup(cls, app: FastAPI, secret_key: str) -> Self:
-        db_admin = cls(app, secret_key)
+    def setup(cls, app: FastAPI, session_middleware: Middleware) -> Self:
+        db_admin = cls(app, session_middleware)
         db_admin.admin.add_view(GroupAdmin)
         db_admin.admin.add_view(Auth0RoleAdmin)
         return db_admin
 
     async def login_auth0(self, request: Request) -> Response:
+        settings = get_settings()
         token = await self.auth0_client.authorize_access_token(request)
-        user = token.get('userinfo')
-        if user:
-            request.session['user'] = user
-        return RedirectResponse(request.url_for("admin:index"))
+        access_token = token.get("access_token")
+        if not access_token:
+            raise HTTPException(status_code=401, detail="Could not get access token.")
+        payload = verify_jwt(access_token, settings)
+        if not payload:
+            raise HTTPException(status_code=401, detail="Could not verify JWT.")
+        if not payload.has_admin_role(settings):
+            raise HTTPException(status_code=401, detail="User does not have admin role.")
+        request.session['biocommons_roles'] = payload.biocommons_roles
+        return RedirectResponse(request.url_for("admin:index"), status_code=302)
 
 
 class GroupAdmin(ModelView, model=BiocommonsGroup):

--- a/db/admin.py
+++ b/db/admin.py
@@ -4,7 +4,6 @@ from authlib.integrations.starlette_client import OAuth
 from fastapi import FastAPI, HTTPException
 from sqladmin import Admin, ModelView
 from sqladmin.authentication import AuthenticationBackend
-from starlette.middleware import Middleware
 from starlette.requests import Request
 from starlette.responses import RedirectResponse, Response
 
@@ -35,8 +34,8 @@ def setup_oauth():
 
 class AdminAuth(AuthenticationBackend):
 
-    def __init__(self, session_middleware: Middleware, auth0_client: OAuth):
-        self.middlewares = [session_middleware]
+    def __init__(self, secret_key: str, auth0_client: OAuth):
+        super().__init__(secret_key=secret_key)
         self.auth0_client = auth0_client
 
     async def login(self, request: Request) -> bool:
@@ -83,24 +82,25 @@ class ApprovalHistoryAdmin(ModelView, model=ApprovalHistory):
 
 
 class DatabaseAdmin:
+    views = (GroupAdmin, Auth0RoleAdmin, GroupMembershipAdmin, ApprovalHistoryAdmin,)
 
-    def __init__(self, app: FastAPI, session_middleware: Middleware):
+    def __init__(self, app: FastAPI, secret_key: str):
         self.app = app
         self.auth0_client = setup_oauth()
         self.admin = Admin(
             app,
             engine=engine,
             base_url="/db_admin",
-            authentication_backend=AdminAuth(session_middleware=session_middleware, auth0_client=self.auth0_client),
+            authentication_backend=AdminAuth(secret_key=secret_key, auth0_client=self.auth0_client),
             title="AAI Backend Admin"
         )
         self.admin.app.router.add_route("/auth/auth0", self.login_auth0)
 
     @classmethod
-    def setup(cls, app: FastAPI, session_middleware: Middleware) -> Self:
-        db_admin = cls(app, session_middleware)
-        db_admin.admin.add_view(GroupAdmin)
-        db_admin.admin.add_view(Auth0RoleAdmin)
+    def setup(cls, app: FastAPI, secret_key: str) -> Self:
+        db_admin = cls(app, secret_key=secret_key)
+        for view in db_admin.views:
+            db_admin.admin.add_view(view)
         return db_admin
 
     async def login_auth0(self, request: Request) -> Response:

--- a/db/admin.py
+++ b/db/admin.py
@@ -4,6 +4,7 @@ from authlib.integrations.starlette_client import OAuth
 from fastapi import FastAPI, HTTPException
 from sqladmin import Admin, ModelView
 from sqladmin.authentication import AuthenticationBackend
+from sqladmin.filters import AllUniqueStringValuesFilter
 from starlette.requests import Request
 from starlette.responses import RedirectResponse, Response
 
@@ -73,6 +74,10 @@ class GroupMembershipAdmin(ModelView, model=GroupMembership):
     can_edit = False
     can_create = False
     column_list = ["name", "group_id", "user_email", "user_id", "approval_status", "updated_at", "updated_by_email"]
+    column_filters = [
+        AllUniqueStringValuesFilter(GroupMembership.group_id),
+        AllUniqueStringValuesFilter(GroupMembership.approval_status)
+    ]
 
 
 class ApprovalHistoryAdmin(ModelView, model=ApprovalHistory):

--- a/db/admin.py
+++ b/db/admin.py
@@ -88,6 +88,7 @@ class ApprovalHistoryAdmin(ModelView, model=ApprovalHistory):
     can_create = False
     can_delete = False
     column_list = ["name", "group_id", "user_email", "user_id", "approval_status", "updated_at", "updated_by_email"]
+    column_default_sort = ("updated_at", True)
 
 
 class DatabaseAdmin:

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ from contextlib import asynccontextmanager
 from dotenv import dotenv_values
 from fastapi import FastAPI
 from starlette.middleware.cors import CORSMiddleware
+from starlette.middleware.sessions import SessionMiddleware
 
 # This has to be imported even if unused
 from db import models  # noqa: F401
@@ -30,6 +31,7 @@ async def lifespan(app: FastAPI):
     yield
 
 app = FastAPI(lifespan=lifespan)
+app.add_middleware(SessionMiddleware, secret_key=SECRET_KEY)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=ALLOWED_ORIGINS,

--- a/main.py
+++ b/main.py
@@ -2,9 +2,7 @@ from contextlib import asynccontextmanager
 
 from dotenv import dotenv_values
 from fastapi import FastAPI
-from starlette.middleware import Middleware
 from starlette.middleware.cors import CORSMiddleware
-from starlette.middleware.sessions import SessionMiddleware
 
 # This has to be imported even if unused
 from db import models  # noqa: F401
@@ -28,10 +26,10 @@ async def lifespan(app: FastAPI):
     # NOTE: we only create the database and tables automatically in development:
     # we assume that if the DB is an sqlite DB, we are in dev.
     create_db_and_tables()
+    DatabaseAdmin.setup(app=app, secret_key=SECRET_KEY)
     yield
 
-session_middleware = Middleware(SessionMiddleware, secret_key=SECRET_KEY, max_age=None)
-app = FastAPI(lifespan=lifespan, middleware=[session_middleware])
+app = FastAPI(lifespan=lifespan)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=ALLOWED_ORIGINS,
@@ -52,5 +50,3 @@ app.include_router(bpa_register.router)
 app.include_router(galaxy_register.router)
 app.include_router(utils.router)
 app.include_router(biocommons_groups.router)
-
-db_admin = DatabaseAdmin.setup(app=app, session_middleware=session_middleware)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,10 @@ dependencies = [
     "pydantic-settings>=2.8.1",
     "python-jose>=3.4.0",
     "sqlmodel>=0.0.24",
-    "boto3>=1.34.0"
+    "boto3>=1.34.0",
+    "authlib>=1.6.1",
+    "sqladmin>=0.21.0",
+    "itsdangerous>=2.2.0",
 ]
 
 [project.optional-dependencies]

--- a/schemas/tokens.py
+++ b/schemas/tokens.py
@@ -2,6 +2,8 @@ from typing import Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from config import Settings
+
 
 class AccessTokenPayload(BaseModel):
     """
@@ -23,3 +25,9 @@ class AccessTokenPayload(BaseModel):
 
     # Set populate_by_name so we can specify biocommons_roles as an argument
     model_config = ConfigDict(populate_by_name=True)
+
+    def has_admin_role(self, settings: Settings) -> bool:
+        for role in self.biocommons_roles:
+            if role in settings.admin_roles:
+                return True
+        return False

--- a/tests/db/test_db_admin.py
+++ b/tests/db/test_db_admin.py
@@ -1,0 +1,100 @@
+import asyncio
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from itsdangerous import URLSafeSerializer
+from starlette.requests import Request
+
+from db.admin import AdminAuth, DatabaseAdmin
+from main import app
+
+
+@pytest.fixture
+def mock_request():
+    """Create a mock request object"""
+    request = Mock(spec=Request)
+    request.session = {}
+    request.url_for = Mock(return_value="http://test.com/login")
+    return request
+
+
+def create_signed_session_cookie(data: dict, secret_key: str) -> str:
+    serializer = URLSafeSerializer(secret_key, salt="starlette.sessions")
+    return serializer.dumps(data)
+
+
+@pytest.fixture
+def enable_db_admin(mocker, mock_settings):
+    mocker.patch("db.admin.get_settings", return_value=mock_settings)
+    dummy_oauth_client = mocker.Mock()
+    mocker.patch("db.admin.setup_oauth", return_value=dummy_oauth_client)
+    DatabaseAdmin.setup(app=app, secret_key="test-secret")
+    yield
+
+
+def test_admin_auth_authenticate_with_admin_role_returns_true(mock_settings):
+    """Test that authenticate returns True when user has admin role"""
+    mock_auth0_client = Mock()
+    admin_auth = AdminAuth(secret_key="test-secret", auth0_client=mock_auth0_client)
+
+    mock_request = Mock()
+    mock_request.session = {"biocommons_roles": ["Admin"]}
+
+    with patch("db.admin.get_settings", return_value=mock_settings):
+        result = asyncio.run(admin_auth.authenticate(mock_request))
+
+    assert result is True
+
+
+def test_admin_auth_authenticate_no_roles_redirects_to_auth0(mock_settings):
+    """Test that authenticate redirects to Auth0 when no roles in session"""
+    mock_auth0_client = Mock()
+    mock_auth0_client.authorize_redirect = AsyncMock()
+    admin_auth = AdminAuth(secret_key="test-secret", auth0_client=mock_auth0_client)
+
+    mock_request = Mock()
+    mock_request.session = {}
+    mock_request.url_for = Mock(return_value="http://test.com/login")
+
+    with patch("db.admin.get_settings", return_value=mock_settings):
+        asyncio.run(admin_auth.authenticate(mock_request))
+
+    mock_auth0_client.authorize_redirect.assert_called_once_with(
+        mock_request, mock_request.url_for.return_value
+    )
+
+
+def test_admin_auth_authenticate_empty_roles_list_redirects(mock_settings):
+    """Test that authenticate redirects when roles list is empty"""
+    mock_auth0_client = Mock()
+    mock_auth0_client.authorize_redirect = AsyncMock(return_value="redirect_response")
+    admin_auth = AdminAuth(secret_key="test-secret", auth0_client=mock_auth0_client)
+
+    mock_request = Mock()
+    mock_request.session = {"biocommons_roles": []}
+    mock_request.url_for = Mock(return_value="http://test.com/login")
+
+    with patch("db.admin.get_settings", return_value=mock_settings):
+        result = asyncio.run(admin_auth.authenticate(mock_request))
+
+    mock_auth0_client.authorize_redirect.assert_called_once()
+    assert result == "redirect_response"
+
+
+def test_admin_panel_access_with_valid_admin_session(test_client, mock_settings):
+    """Test that admin panel is accessible with valid admin session"""
+    with patch("db.admin.get_settings", return_value=mock_settings), \
+            patch("db.admin.setup_oauth") as mock_setup_oauth:
+        mock_oauth_client = Mock()
+        mock_oauth_client.authorize_redirect = AsyncMock()
+        mock_oauth_client.authorize_access_token = AsyncMock()
+        mock_setup_oauth.return_value = mock_oauth_client
+
+        DatabaseAdmin.setup(app=test_client.app, secret_key="test-secret")
+
+        roles_data = {"biocommons_roles": ["Admin"]}
+        cookie_value = create_signed_session_cookie(roles_data, "test-secret")
+        test_client.cookies.set("session", cookie_value)
+
+        resp = test_client.get('/db_admin/')
+        assert resp.status_code == 200

--- a/uv.lock
+++ b/uv.lock
@@ -8,12 +8,15 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
+    { name = "authlib" },
     { name = "boto3" },
     { name = "fastapi", extra = ["standard"] },
     { name = "httpx" },
+    { name = "itsdangerous" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pydantic-settings" },
     { name = "python-jose" },
+    { name = "sqladmin" },
     { name = "sqlmodel" },
 ]
 
@@ -34,10 +37,12 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "alembic", specifier = ">=1.16.2" },
+    { name = "authlib", specifier = ">=1.6.1" },
     { name = "boto3", specifier = ">=1.34.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.12" },
     { name = "freezegun", marker = "extra == 'dev'", specifier = ">=1.5.2" },
     { name = "httpx", specifier = ">=0.28.1" },
+    { name = "itsdangerous", specifier = ">=2.2.0" },
     { name = "mimesis", marker = "extra == 'dev'", specifier = "~=18.0" },
     { name = "moto", marker = "extra == 'dev'", specifier = ">=5.0.5" },
     { name = "polyfactory", marker = "extra == 'dev'", specifier = ">=2.21.0" },
@@ -50,6 +55,7 @@ requires-dist = [
     { name = "python-jose", specifier = ">=3.4.0" },
     { name = "respx", marker = "extra == 'dev'", specifier = ">=0.22.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4.4" },
+    { name = "sqladmin", specifier = ">=0.21.0" },
     { name = "sqlmodel", specifier = ">=0.0.24" },
 ]
 provides-extras = ["dev"]
@@ -88,6 +94,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/95/7d/4c1bd541d4dffa1b52bd83fb8527089e097a106fc90b467a7313b105f840/anyio-4.9.0.tar.gz", hash = "sha256:673c0c244e15788651a4ff38710fea9675823028a6f08a5eda409e0c9840a028", size = 190949, upload-time = "2025-03-17T00:02:54.77Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a1/ee/48ca1a7c89ffec8b6a0c5d02b89c305671d5ffd8d3c94acf8b8c408575bb/anyio-4.9.0-py3-none-any.whl", hash = "sha256:9f76d541cad6e36af7beb62e978876f3b41e3e04f2c1fbf0884604c0a9c4d93c", size = 100916, upload-time = "2025-03-17T00:02:52.713Z" },
+]
+
+[[package]]
+name = "authlib"
+version = "1.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/a1/d8d1c6f8bc922c0b87ae0d933a8ed57be1bef6970894ed79c2852a153cd3/authlib-1.6.1.tar.gz", hash = "sha256:4dffdbb1460ba6ec8c17981a4c67af7d8af131231b5a36a88a1e8c80c111cdfd", size = 159988, upload-time = "2025-07-20T07:38:42.834Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/58/cc6a08053f822f98f334d38a27687b69c6655fb05cd74a7a5e70a2aeed95/authlib-1.6.1-py2.py3-none-any.whl", hash = "sha256:e9d2031c34c6309373ab845afc24168fe9e93dc52d252631f52642f21f5ed06e", size = 239299, upload-time = "2025-07-20T07:38:39.259Z" },
 ]
 
 [[package]]
@@ -487,6 +505,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
+]
+
+[[package]]
+name = "itsdangerous"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/cb/8ac0172223afbccb63986cc25049b154ecfb5e85932587206f42317be31d/itsdangerous-2.2.0.tar.gz", hash = "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173", size = 54410, upload-time = "2024-04-16T21:28:15.614Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl", hash = "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef", size = 16234, upload-time = "2024-04-16T21:28:14.499Z" },
 ]
 
 [[package]]
@@ -1032,6 +1059,22 @@ wheels = [
 ]
 
 [[package]]
+name = "sqladmin"
+version = "0.21.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "python-multipart" },
+    { name = "sqlalchemy" },
+    { name = "starlette" },
+    { name = "wtforms" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/0c/614041e1b544e0de1f43b58f0105b3e2795b80369d5b0ff7412882d42fff/sqladmin-0.21.0.tar.gz", hash = "sha256:cb455b79eb79ef7d904680dd83817bf7750675147400b5b7cc401d04bda7ef2c", size = 1428312, upload-time = "2025-07-02T09:41:21.207Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/8d/81b2a48cc6f5479cb1148292518e3006ec8f5fbe3b0829ef165984e9d7b9/sqladmin-0.21.0-py3-none-any.whl", hash = "sha256:2b1802c49bdd3128c6452625705693cf32d5d33e7db30e63f409bd20a9c05b53", size = 1443585, upload-time = "2025-07-02T09:41:19.205Z" },
+]
+
+[[package]]
 name = "sqlalchemy"
 version = "2.0.41"
 source = { registry = "https://pypi.org/simple" }
@@ -1267,6 +1310,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9f/69/83029f1f6300c5fb2471d621ab06f6ec6b3324685a2ce0f9777fd4a8b71e/werkzeug-3.1.3.tar.gz", hash = "sha256:60723ce945c19328679790e3282cc758aa4a6040e4bb330f53d30fa546d44746", size = 806925, upload-time = "2024-11-08T15:52:18.093Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/52/24/ab44c871b0f07f491e5d2ad12c9bd7358e527510618cb1b803a88e986db1/werkzeug-3.1.3-py3-none-any.whl", hash = "sha256:54b78bf3716d19a65be4fceccc0d1d7b89e608834989dfae50ea87564639213e", size = 224498, upload-time = "2024-11-08T15:52:16.132Z" },
+]
+
+[[package]]
+name = "wtforms"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/c7/96d10183c3470f1836846f7b9527d6cb0b6c2226ebca40f36fa29f23de60/wtforms-3.1.2.tar.gz", hash = "sha256:f8d76180d7239c94c6322f7990ae1216dae3659b7aa1cee94b6318bdffb474b9", size = 134705, upload-time = "2024-01-06T07:52:41.075Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/19/c3232f35e24dccfad372e9f341c4f3a1166ae7c66e4e1351a9467c921cc1/wtforms-3.1.2-py3-none-any.whl", hash = "sha256:bf831c042829c8cdbad74c27575098d541d039b1faa74c771545ecac916f2c07", size = 145961, upload-time = "2024-01-06T07:52:43.023Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

[AAI-281](https://biocloud.atlassian.net/browse/AAI-281): implement a GUI to view/manage the AAI backend's database, using https://aminalaee.github.io/sqladmin/ . 

<img width="1708" height="450" alt="Screenshot 2025-07-29 at 9 41 08 am" src="https://github.com/user-attachments/assets/4ec40f77-d005-4ad4-8ba1-a6e1e87adbf7" />


## Changes

- Set up sqladmin against our DB
- Authenticate access to the admin using Auth0 roles (user has to have one of the roles configured in `ADMIN_ROLES`)
- Add our existing DB models to the admin (view-only permission for now)
- Unit tests of access/authentication to the DB

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit / integration tests that prove my fix is effective or that my feature works
- [x] I have run all tests locally and they pass
- [x] I have updated the documentation (if applicable)

## How to Test Manually (if necessary)

Run `uv run fastapi dev` and visit `localhost:8000/db_admin`: you must have `ADMIN_ROLES` set to include a role like `biocommons/role/biocommons/admin` in `.env`, and your Auth0 user account must have this role.


[AAI-281]: https://biocloud.atlassian.net/browse/AAI-281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ