### PR TITLE
AAI-281 Forward proxy headers so static files for DB admin can be loaded

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,4 @@ FROM ghcr.io/astral-sh/uv:python3.13-alpine
 ADD . /app
 WORKDIR /app
 RUN uv sync --locked
-CMD ["uv", "run", "fastapi", "run", "--host", "0.0.0.0", "--port", "8000", "--workers", "2"]
+CMD ["uv", "run", "fastapi", "run", "--host", "0.0.0.0", "--port", "8000", "--workers", "2", "--proxy-headers", "--forwarded-allow-ips", "*"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,4 @@ FROM ghcr.io/astral-sh/uv:python3.13-alpine
 ADD . /app
 WORKDIR /app
 RUN uv sync --locked
-CMD ["uv", "run", "fastapi", "run", "--host", "0.0.0.0", "--port", "8000", "--workers", "2", "--proxy-headers", "--forwarded-allow-ips", "*"]
+CMD ["uv", "run", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "2", "--proxy-headers", "--forwarded-allow-ips", "*"]


### PR DESCRIPTION
## Description

[AAI-281](https://biocloud.atlassian.net/browse/AAI-281): need to forward headers from the AWS load balancer so that the JS/CSS files the database admin uses can be loaded properly. See https://aminalaee.github.io/sqladmin/cookbook/deployment_with_https/

Note these options are potentially insecure for a web service exposed directly to the internet, but our service is only exposed to the AWS load balancer.

## Changes

- Update docker run command to include `--proxy-headers` and `--forwarded-allow-ips` options


## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit / integration tests that prove my fix is effective or that my feature works
- [x] I have run all tests locally and they pass
- [x] I have updated the documentation (if applicable)

## How to Test Manually (if necessary)

Build the docker image locally and run it:

```sh
docker build -t aai_backend .
docker run -p 8000:8000 aai_backend
```


[AAI-281]: https://biocloud.atlassian.net/browse/AAI-281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ