### PR TITLE
AAI-268 Get or create the Auth0 role before adding it to the DB

### DIFF
--- a/auth0/client.py
+++ b/auth0/client.py
@@ -218,6 +218,13 @@ class Auth0Client:
         resp.raise_for_status()
         return RoleData(**resp.json())
 
+    def get_or_create_role(self, name: str, description: str) -> RoleData:
+        try:
+            role = self.get_role_by_name(name)
+        except ValueError:
+            role = self.create_role(name, description)
+        return role
+
 
 def get_auth0_client(settings: Settings = Depends(get_settings),
                      management_token: str = Depends(get_management_token)):

--- a/routers/biocommons_groups.py
+++ b/routers/biocommons_groups.py
@@ -158,12 +158,12 @@ def create_role(
         auth0_client: Annotated[Auth0Client, Depends(get_auth0_client)]
     ):
     """
-    Create a new role in Auth0 and add it to the DB.
+    Create a new role in Auth0 (if needed) and add it to the DB.
     Note that our "RoleId/GroupId" is actually the
     Auth0 role name - Auth0 has its own internal IDs
     """
-    logger.info(f"Creating role {role_data.name} in Auth0")
-    resp = auth0_client.create_role(**role_data.model_dump())
+    logger.info(f"Creating role {role_data.name} in Auth0 if needed")
+    resp = auth0_client.get_or_create_role(**role_data.model_dump())
     logger.info("Saving to database")
     role = Auth0Role(**resp.model_dump())
     db_session.add(role)

--- a/tests/biocommons/test_api.py
+++ b/tests/biocommons/test_api.py
@@ -60,11 +60,13 @@ def test_create_group(test_client, as_admin_user, override_auth0_client, test_db
 
 @pytest.mark.parametrize("role_name", ["biocommons/role/tsi/admin", "biocommons/group/tsi"])
 @respx.mock
-def test_create_role(role_name, test_client, as_admin_user, override_auth0_client, test_db_session):
+def test_create_role(role_name, test_client, as_admin_user, override_auth0_client, test_db_session, mocker):
     """
     Test we can create Auth0 roles using either the format for roles or groups.
     """
     mock_resp = RoleDataFactory.build(name=role_name)
+    # Patch check of existing role
+    mocker.patch("auth0.client.Auth0Client.get_role_by_name", side_effect=ValueError)
     route = respx.post("https://auth0.example.com/api/v2/roles").mock(
         return_value=Response(200, json=mock_resp.model_dump(mode="json"))
     )
@@ -77,6 +79,27 @@ def test_create_role(role_name, test_client, as_admin_user, override_auth0_clien
     )
     assert resp.status_code == 200
     assert route.called
+    role_from_db = test_db_session.exec(select(Auth0Role).where(Auth0Role.name == role_name)).one()
+    assert role_from_db.name == role_name
+
+
+@pytest.mark.parametrize("role_name", ["biocommons/role/tsi/admin", "biocommons/group/tsi"])
+def test_create_role_already_exists(role_name, test_client, as_admin_user, override_auth0_client, test_db_session, mocker):
+    """
+    Test we can add existing Auth0 roles to the DB
+    """
+    mock_resp = RoleDataFactory.build(name=role_name)
+    # Patch check of existing role
+    mocker.patch("auth0.client.Auth0Client.get_role_by_name", return_value=mock_resp)
+    # No call to Auth0 API to create when the role already exists
+    resp = test_client.post(
+        "/biocommons/roles/create",
+        json={
+            "name": role_name,
+            "description": "Admin role for Threatened Species Initiative"
+        }
+    )
+    assert resp.status_code == 200
     role_from_db = test_db_session.exec(select(Auth0Role).where(Auth0Role.name == role_name)).one()
     assert role_from_db.name == role_name
 


### PR DESCRIPTION
## Description

[AAI-268](https://biocloud.atlassian.net/browse/AAI-268): allow for roles already existing when calling the API to add them to the database

## Changes

- Check for existing Auth0 role and only create it if needed
- Unit tests
- 
## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit / integration tests that prove my fix is effective or that my feature works
- [x] I have run all tests locally and they pass
- [x] I have updated the documentation (if applicable)

## How to Test Manually (if necessary)

Run `uv run pytest`


[AAI-268]: https://biocloud.atlassian.net/browse/AAI-268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ