### PR TITLE
Implement Biocommons user registration endpoint

### DIFF
--- a/db/admin.py
+++ b/db/admin.py
@@ -13,6 +13,7 @@ from config import get_settings
 from db.models import (
     Auth0Role,
     BiocommonsGroup,
+    BiocommonsUser,
     GroupMembership,
     GroupMembershipHistory,
 )
@@ -32,11 +33,11 @@ def setup_oauth():
         api_base_url=f"https://{settings.auth0_domain}",
         access_token_url=f"https://{settings.auth0_domain}/oauth/token",
         authorize_url=f"https://{settings.auth0_domain}/authorize",
-        server_metadata_url=f'https://{settings.auth0_domain}/.well-known/openid-configuration',
+        server_metadata_url=f"https://{settings.auth0_domain}/.well-known/openid-configuration",
         client_kwargs={
             "scope": "openid profile email",
-            "audience": settings.auth0_audience
-        }
+            "audience": settings.auth0_audience,
+        },
     )
     return oauth.create_client("auth0")
 
@@ -63,12 +64,20 @@ class AdminAuth(AuthenticationBackend):
         roles = request.session.get("biocommons_roles")
         if not roles:
             print("Redirecting to Auth0 for login.")
-            redirect_uri = request.url_for('login_auth0')
+            redirect_uri = request.url_for("login_auth0")
             return await self.auth0_client.authorize_redirect(request, redirect_uri)
         for role in roles:
             if role in settings.admin_roles:
                 return True
         return False
+
+
+class BiocommonsUserAdmin(ModelView, model=BiocommonsUser):
+    can_edit = False
+    can_create = False
+    can_delete = False
+    column_list = ["id", "username", "email", "created_at"]
+    column_default_sort = ("created_at", True)
 
 
 class GroupAdmin(ModelView, model=BiocommonsGroup):
@@ -88,10 +97,18 @@ class GroupMembershipAdmin(ModelView, model=GroupMembership):
     can_edit = False
     can_create = False
     can_delete = False
-    column_list = ["name", "group_id", "user_email", "user_id", "approval_status", "updated_at", "updated_by_email"]
+    column_list = [
+        "name",
+        "group_id",
+        "user_email",
+        "user_id",
+        "approval_status",
+        "updated_at",
+        "updated_by_email",
+    ]
     column_filters = [
         AllUniqueStringValuesFilter(GroupMembership.group_id),
-        AllUniqueStringValuesFilter(GroupMembership.approval_status)
+        AllUniqueStringValuesFilter(GroupMembership.approval_status),
     ]
 
 
@@ -99,7 +116,15 @@ class GroupMembershipHistoryAdmin(ModelView, model=GroupMembershipHistory):
     can_edit = False
     can_create = False
     can_delete = False
-    column_list = ["name", "group_id", "user_email", "user_id", "approval_status", "updated_at", "updated_by_email"]
+    column_list = [
+        "name",
+        "group_id",
+        "user_email",
+        "user_id",
+        "approval_status",
+        "updated_at",
+        "updated_by_email",
+    ]
     column_default_sort = ("updated_at", True)
 
 
@@ -107,7 +132,14 @@ class DatabaseAdmin:
     """
     Sets up the Admin app for the database.
     """
-    views = (GroupAdmin, Auth0RoleAdmin, GroupMembershipAdmin, GroupMembershipHistoryAdmin,)
+
+    views = (
+        BiocommonsUserAdmin,
+        GroupAdmin,
+        Auth0RoleAdmin,
+        GroupMembershipAdmin,
+        GroupMembershipHistoryAdmin,
+    )
 
     def __init__(self, app: FastAPI, secret_key: str):
         self.app = app
@@ -116,8 +148,10 @@ class DatabaseAdmin:
             app,
             engine=get_engine(),
             base_url="/db_admin",
-            authentication_backend=AdminAuth(secret_key=secret_key, auth0_client=self.auth0_client),
-            title="AAI Backend Admin"
+            authentication_backend=AdminAuth(
+                secret_key=secret_key, auth0_client=self.auth0_client
+            ),
+            title="AAI Backend Admin",
         )
         self.admin.app.router.add_route("/auth/auth0", self.login_auth0)
 
@@ -138,6 +172,8 @@ class DatabaseAdmin:
         if not payload:
             raise HTTPException(status_code=401, detail="Could not verify JWT.")
         if not payload.has_admin_role(settings):
-            raise HTTPException(status_code=401, detail="User does not have admin role.")
-        request.session['biocommons_roles'] = payload.biocommons_roles
+            raise HTTPException(
+                status_code=401, detail="User does not have admin role."
+            )
+        request.session["biocommons_roles"] = payload.biocommons_roles
         return RedirectResponse(request.url_for("admin:index"), status_code=302)

--- a/main.py
+++ b/main.py
@@ -8,7 +8,15 @@ from starlette.middleware.sessions import SessionMiddleware
 # This has to be imported even if unused
 from db import models  # noqa: F401
 from db.admin import DatabaseAdmin
-from routers import admin, biocommons_groups, bpa_register, galaxy_register, user, utils
+from routers import (
+    admin,
+    biocommons_groups,
+    biocommons_register,
+    bpa_register,
+    galaxy_register,
+    user,
+    utils,
+)
 
 # Load .env to get CORS_ALLOWED_ORIGINS.
 # Note that for most env variables, we use pydantic-settings
@@ -26,9 +34,11 @@ async def lifespan(app: FastAPI):
     # NOTE: we only create the database and tables automatically in development:
     # we assume that if the DB is an sqlite DB, we are in dev.
     from db.setup import create_db_and_tables
+
     create_db_and_tables()
     DatabaseAdmin.setup(app=app, secret_key=SECRET_KEY)
     yield
+
 
 app = FastAPI(lifespan=lifespan)
 app.add_middleware(SessionMiddleware, secret_key=SECRET_KEY)
@@ -48,6 +58,7 @@ def public_route():
 
 app.include_router(admin.router)
 app.include_router(user.router)
+app.include_router(biocommons_register.router)
 app.include_router(bpa_register.router)
 app.include_router(galaxy_register.router)
 app.include_router(utils.router)

--- a/routers/biocommons_register.py
+++ b/routers/biocommons_register.py
@@ -11,12 +11,15 @@ from config import Settings, get_settings
 from db.models import BiocommonsGroup, BiocommonsUser, PlatformEnum
 from db.setup import get_db_session
 from schemas.biocommons import Auth0UserData, BiocommonsRegisterData
-from schemas.biocommons_register import BiocommonsRegistrationRequest
+from schemas.biocommons_register import BiocommonsRegistrationRequest, BundleType
 
 logger = logging.getLogger(__name__)
 
 # Bundle configuration mapping bundle names to their groups and included platforms
-BUNDLES = {
+# Note: Platforms listed here are auto-approved upon registration,
+# while group memberships require manual approval
+# Currently BPA Data Portal and Galaxy are auto-approved for all bundles
+BUNDLES: dict[BundleType, dict] = {
     "bpa-galaxy": {
         "group_id": "biocommons/group/bpa_galaxy",
         "platforms": [PlatformEnum.BPA_DATA_PORTAL, PlatformEnum.GALAXY],
@@ -131,7 +134,7 @@ def _create_biocommons_user_record(
     # Add platform memberships based on bundle configuration
     for platform in bundle_config["platforms"]:
         platform_membership = db_user.add_platform_membership(
-            platform=platform, db_session=session, auto_approve=False
+            platform=platform, db_session=session, auto_approve=True
         )
         session.add(platform_membership)
 

--- a/routers/biocommons_register.py
+++ b/routers/biocommons_register.py
@@ -1,0 +1,140 @@
+import logging
+from typing import Any, Dict
+
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
+from httpx import HTTPStatusError
+from sqlmodel import Session
+
+from auth.ses import EmailService
+from auth0.client import Auth0Client, get_auth0_client
+from config import Settings, get_settings
+from db.models import BiocommonsGroup, BiocommonsUser, PlatformEnum
+from db.setup import get_db_session
+from schemas.biocommons import Auth0UserData, BiocommonsRegisterData
+from schemas.biocommons_register import BiocommonsRegistrationRequest
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/biocommons", tags=["biocommons", "registration"])
+
+
+def send_approval_email(registration: BiocommonsRegistrationRequest):
+    """Send email notification about new biocommons registration."""
+    email_service = EmailService()
+    approver_email = "aai-dev@biocommons.org.au"
+    subject = "New BioCommons User Registration"
+
+    body_html = f"""
+        <p>A new user has registered for the BioCommons platform.</p>
+        <p><strong>User:</strong> {registration.first_name} {registration.last_name} ({registration.email})</p>
+        <p><strong>Username:</strong> {registration.username}</p>
+        <p><strong>Selected Bundle:</strong> {registration.bundle}</p>
+        <p><strong>Requested Access:</strong> BPA Data Portal & Galaxy Australia</p>
+        <p>Please <a href='https://aaiportal.test.biocommons.org.au/requests'>log into the AAI Admin Portal</a> to review and approve access.</p>
+    """
+
+    email_service.send(approver_email, subject, body_html)
+
+
+@router.post(
+    "/register",
+    response_model=Dict[str, Any],
+    responses={
+        400: {"description": "Bad Request - Validation error"},
+        409: {"description": "Conflict - User already exists"},
+        500: {"description": "Internal server error"},
+    },
+)
+async def register_biocommons_user(
+    registration: BiocommonsRegistrationRequest,
+    background_tasks: BackgroundTasks,
+    settings: Settings = Depends(get_settings),
+    db_session: Session = Depends(get_db_session),
+    auth0_client: Auth0Client = Depends(get_auth0_client),
+) -> Dict[str, Any]:
+    """Register a new BioCommons user."""
+
+    # Create Auth0 user data
+    user_data = BiocommonsRegisterData.from_biocommons_registration(registration)
+
+    try:
+        logger.info("Registering user with Auth0")
+        auth0_user_data = auth0_client.create_user(user_data)
+
+        logger.info("Adding user to DB")
+        _create_biocommons_user_record(auth0_user_data, registration, db_session)
+
+        # Send approval email in background
+        if settings.send_email:
+            background_tasks.add_task(send_approval_email, registration)
+
+        logger.info(
+            f"Successfully registered biocommons user: {auth0_user_data.user_id}"
+        )
+        return {
+            "message": "User registered successfully",
+            "user": auth0_user_data.model_dump(mode="json"),
+        }
+
+    except HTTPStatusError as e:
+        logger.error(f"Auth0 registration failed: {e}")
+        error_detail = "Registration failed"
+        if e.response.status_code == 409:
+            error_detail = "User already exists"
+        elif e.response.status_code == 400:
+            error_detail = "Invalid registration data"
+        raise HTTPException(status_code=e.response.status_code, detail=error_detail)
+    except Exception as e:
+        logger.error(f"Unexpected error during registration: {e}")
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+def _create_biocommons_user_record(
+    auth0_user_data: Auth0UserData,
+    registration: BiocommonsRegistrationRequest,
+    session: Session,
+) -> BiocommonsUser:
+    """Create a BioCommons user record in the database with group membership based on selected bundle."""
+    db_user = BiocommonsUser.from_auth0_data(data=auth0_user_data)
+    session.add(db_user)
+    session.flush()
+
+    # Map bundle to group information
+    bundle_group_map = {
+        "bpa-galaxy": {
+            "id": "biocommons/group/bpa_galaxy",
+            "name": "BPA Data Portal & Galaxy Access",
+        },
+        "tsi": {"id": "biocommons/group/tsi", "name": "Threatened Species Initiative"},
+    }
+
+    group_info = bundle_group_map[registration.bundle]
+
+    # Create or get the BiocommonsGroup record
+    db_group = session.get(BiocommonsGroup, group_info["id"])
+    if not db_group:
+        db_group = BiocommonsGroup(
+            group_id=group_info["id"],
+            name=group_info["name"],
+            admin_roles=[],
+        )
+        session.add(db_group)
+        session.flush()
+
+    # Create group membership
+    group_membership = db_user.add_group_membership(
+        group_id=group_info["id"], db_session=session, auto_approve=False
+    )
+    session.add(group_membership)
+
+    # Add platform memberships based on bundle
+    platforms_to_add = [PlatformEnum.BPA_DATA_PORTAL, PlatformEnum.GALAXY]
+
+    for platform in platforms_to_add:
+        platform_membership = db_user.add_platform_membership(
+            platform=platform, db_session=session, auto_approve=False
+        )
+        session.add(platform_membership)
+
+    session.commit()
+    return db_user

--- a/schemas/biocommons_register.py
+++ b/schemas/biocommons_register.py
@@ -1,0 +1,16 @@
+from typing import Literal
+
+from pydantic import BaseModel, EmailStr
+
+from schemas.biocommons import BiocommonsPassword, BiocommonsUsername
+
+BundleType = Literal["bpa-galaxy", "tsi"]
+
+
+class BiocommonsRegistrationRequest(BaseModel):
+    first_name: str
+    last_name: str
+    email: EmailStr
+    username: BiocommonsUsername
+    password: BiocommonsPassword
+    bundle: BundleType

--- a/tests/datagen.py
+++ b/tests/datagen.py
@@ -5,6 +5,7 @@ from polyfactory.decorators import post_generated
 from polyfactory.factories.pydantic_factory import ModelFactory
 
 from schemas.biocommons import Auth0UserData, BiocommonsAppMetadata
+from schemas.biocommons_register import BiocommonsRegistrationRequest
 from schemas.bpa import BPARegistrationRequest
 from schemas.galaxy import GalaxyRegistrationData
 from schemas.tokens import AccessTokenPayload
@@ -12,11 +13,11 @@ from schemas.user import SessionUser
 
 
 def random_auth0_id() -> str:
-    return "auth0|" + ''.join(random.choices('0123456789abcdef', k=24))
+    return "auth0|" + "".join(random.choices("0123456789abcdef", k=24))
 
 
 def random_auth0_role_id() -> str:
-    return "rol_" + ''.join(random.choices(ascii_letters + digits, k=16))
+    return "rol_" + "".join(random.choices(ascii_letters + digits, k=16))
 
 
 class AccessTokenPayloadFactory(ModelFactory[AccessTokenPayload]):
@@ -31,14 +32,12 @@ class SessionUserFactory(ModelFactory[SessionUser]): ...
 
 
 class Auth0UserDataFactory(ModelFactory[Auth0UserData]):
-
     @classmethod
     def user_id(cls) -> str:
         return random_auth0_id()
 
 
 class GalaxyRegistrationDataFactory(ModelFactory[GalaxyRegistrationData]):
-
     @post_generated
     @classmethod
     def password_confirmation(cls, password: str) -> str:
@@ -62,3 +61,11 @@ class BPARegistrationDataFactory(ModelFactory[BPARegistrationRequest]):
 
 
 class AppMetadataFactory(ModelFactory[BiocommonsAppMetadata]): ...
+
+
+class BiocommonsRegistrationDataFactory(ModelFactory[BiocommonsRegistrationRequest]):
+    """Factory for generating BioCommons registration test data."""
+
+    @classmethod
+    def bundle(cls) -> str:
+        return "bpa-galaxy"

--- a/tests/test_biocommons_register.py
+++ b/tests/test_biocommons_register.py
@@ -103,7 +103,7 @@ def test_create_biocommons_user_record_bpa_galaxy_bundle(test_db_session):
     assert PlatformEnum.GALAXY in platform_ids
 
     for pm in user.platform_memberships:
-        assert pm.approval_status.value == "pending"
+        assert pm.approval_status.value == "approved"
 
 
 def test_create_biocommons_user_record_tsi_bundle(test_db_session):

--- a/tests/test_biocommons_register.py
+++ b/tests/test_biocommons_register.py
@@ -1,0 +1,206 @@
+import pytest
+
+from schemas.biocommons import BiocommonsRegisterData
+from schemas.biocommons_register import BiocommonsRegistrationRequest
+from tests.datagen import Auth0UserDataFactory
+
+
+def test_biocommons_registration_data_excludes_null_user_metadata():
+    """Test that user_metadata is excluded when None and basic Auth0 data is correct"""
+    req = BiocommonsRegistrationRequest(
+        first_name="Test",
+        last_name="User",
+        email="test@example.com",
+        username="testuser",
+        password="StrongPass1!",
+        bundle="bpa-galaxy",
+    )
+
+    user_data = BiocommonsRegisterData.from_biocommons_registration(req)
+
+    assert user_data.user_metadata is None
+
+    dumped = user_data.model_dump(mode="json")
+    assert "user_metadata" not in dumped
+
+    # Test that all required fields are present
+    assert dumped["email"] == "test@example.com"
+    assert dumped["username"] == "testuser"
+    assert dumped["name"] == "Test User"
+    assert dumped["password"] == "StrongPass1!"
+    assert dumped["connection"] == "Username-Password-Authentication"
+    assert dumped["email_verified"] is False
+
+    assert "app_metadata" in dumped
+    app_metadata = dumped["app_metadata"]
+    assert app_metadata["registration_from"] == "biocommons"
+    assert app_metadata.get("services", []) == []
+    assert app_metadata.get("groups", []) == []
+
+
+def test_biocommons_registration_tsi_bundle():
+    """Test TSI bundle registration creates correct basic Auth0 data"""
+    req = BiocommonsRegistrationRequest(
+        first_name="TSI",
+        last_name="User",
+        email="tsi@example.com",
+        username="tsiuser",
+        password="StrongPass1!",
+        bundle="tsi",
+    )
+
+    user_data = BiocommonsRegisterData.from_biocommons_registration(req)
+    dumped = user_data.model_dump(mode="json")
+
+    assert dumped["name"] == "TSI User"
+    assert dumped["app_metadata"]["registration_from"] == "biocommons"
+    assert dumped["app_metadata"].get("groups", []) == []
+    assert dumped["app_metadata"].get("services", []) == []
+
+
+def test_create_biocommons_user_record_bpa_galaxy_bundle(test_db_session):
+    """Test database record creation for bpa-galaxy bundle"""
+    from db.models import PlatformEnum
+    from routers.biocommons_register import _create_biocommons_user_record
+
+    registration = BiocommonsRegistrationRequest(
+        first_name="BPA",
+        last_name="Galaxy",
+        email="bpa.galaxy@example.com",
+        username="bpagalaxy",
+        password="StrongPass1!",
+        bundle="bpa-galaxy",
+    )
+
+    auth0_data = Auth0UserDataFactory.build(
+        email="bpa.galaxy@example.com",
+        username="bpagalaxy",
+        name="BPA Galaxy",
+        user_id="auth0|bpagalaxy123",
+    )
+
+    # Create user record
+    user = _create_biocommons_user_record(auth0_data, registration, test_db_session)
+
+    # Verify user basic data
+    assert user.username == "bpagalaxy"
+    assert user.email == "bpa.galaxy@example.com"
+    assert user.id == "auth0|bpagalaxy123"
+
+    # Verify group membership
+    assert len(user.group_memberships) == 1
+    group_membership = user.group_memberships[0]
+    assert group_membership.group_id == "biocommons/group/bpa_galaxy"
+    assert group_membership.approval_status.value == "pending"
+
+    # Verify platform memberships (should have both BPA and Galaxy)
+    assert len(user.platform_memberships) == 2
+    platform_ids = {pm.platform_id for pm in user.platform_memberships}
+    assert PlatformEnum.BPA_DATA_PORTAL in platform_ids
+    assert PlatformEnum.GALAXY in platform_ids
+
+    # Verify all platform memberships are pending
+    for pm in user.platform_memberships:
+        assert pm.approval_status.value == "pending"
+
+
+def test_create_biocommons_user_record_tsi_bundle(test_db_session):
+    """Test database record creation for tsi bundle"""
+    from db.models import PlatformEnum
+    from routers.biocommons_register import _create_biocommons_user_record
+
+    registration = BiocommonsRegistrationRequest(
+        first_name="TSI",
+        last_name="User",
+        email="tsi.user@example.com",
+        username="tsiuser",
+        password="StrongPass1!",
+        bundle="tsi",
+    )
+
+    auth0_data = Auth0UserDataFactory.build(
+        email="tsi.user@example.com",
+        username="tsiuser",
+        name="TSI User",
+        user_id="auth0|tsiuser123",
+    )
+
+    # Create user record
+    user = _create_biocommons_user_record(auth0_data, registration, test_db_session)
+
+    # Verify user basic data
+    assert user.username == "tsiuser"
+    assert user.email == "tsi.user@example.com"
+
+    # Verify group membership (should be TSI group)
+    assert len(user.group_memberships) == 1
+    group_membership = user.group_memberships[0]
+    assert group_membership.group_id == "biocommons/group/tsi"
+    assert group_membership.approval_status.value == "pending"
+
+    # Verify platform memberships (should still have both BPA and Galaxy)
+    assert len(user.platform_memberships) == 2
+    platform_ids = {pm.platform_id for pm in user.platform_memberships}
+    assert PlatformEnum.BPA_DATA_PORTAL in platform_ids
+    assert PlatformEnum.GALAXY in platform_ids
+
+
+def test_biocommons_group_creation(test_db_session):
+    """Test that BiocommonsGroup records are created when they don't exist"""
+    from db.models import BiocommonsGroup
+    from routers.biocommons_register import _create_biocommons_user_record
+
+    registration = BiocommonsRegistrationRequest(
+        first_name="New",
+        last_name="Group",
+        email="new.group@example.com",
+        username="newgroup",
+        password="StrongPass1!",
+        bundle="bpa-galaxy",
+    )
+
+    auth0_data = Auth0UserDataFactory.build(
+        email="new.group@example.com", username="newgroup", user_id="auth0|newgroup123"
+    )
+
+    # Verify group doesn't exist initially
+    group = test_db_session.get(BiocommonsGroup, "biocommons/group/bpa_galaxy")
+    assert group is None
+
+    # Create user record (should create group)
+    _create_biocommons_user_record(auth0_data, registration, test_db_session)
+
+    # Verify group was created
+    group = test_db_session.get(BiocommonsGroup, "biocommons/group/bpa_galaxy")
+    assert group is not None
+    assert group.group_id == "biocommons/group/bpa_galaxy"
+    assert group.name == "BPA Data Portal & Galaxy Access"
+    assert group.admin_roles == []
+
+
+def test_bundle_validation():
+    """Test that only valid bundles are accepted"""
+    with pytest.raises(ValueError):
+        BiocommonsRegistrationRequest(
+            first_name="Invalid",
+            last_name="Bundle",
+            email="invalid@example.com",
+            username="invalid",
+            password="StrongPass1!",
+            bundle="invalid-bundle",
+        )
+
+
+def test_biocommons_registration_name_formatting():
+    """Test that first_name and last_name are properly combined"""
+    req = BiocommonsRegistrationRequest(
+        first_name="John",
+        last_name="Doe-Smith",
+        email="john.doe@example.com",
+        username="johndoe",
+        password="StrongPass1!",
+        bundle="tsi",
+    )
+
+    user_data = BiocommonsRegisterData.from_biocommons_registration(req)
+    assert user_data.name == "John Doe-Smith"


### PR DESCRIPTION
## Description

[AAI-287](https://biocloud.atlassian.net/jira/software/c/projects/AAI/boards/53?assignee=63f30233526117e1514b222b&selectedIssue=AAI-287): Add Biocommons account registration back-end endpoint & connect to front-end

## Changes

- Added biocommons_register router for user registration.
- Created BiocommonsRegistrationRequest schema for registration data validation.
- Implemented user record creation logic in the database.
- Added email notification for new user registrations.
- Updated tests for biocommons user registration functionality.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit / integration tests that prove my fix is effective or that my feature works
- [x] I have run all tests locally and they pass
- [x] I have updated the documentation (if applicable)


[AAI-287]: https://biocloud.atlassian.net/browse/AAI-287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ