### PR TITLE
AAI-289 Add a more useful response for registration errors

### DIFF
--- a/auth0/client.py
+++ b/auth0/client.py
@@ -92,6 +92,7 @@ class Auth0Client:
     def get_user(self, user_id: str) -> Auth0UserData:
         url = f"https://{self.domain}/api/v2/users/{user_id}"
         resp = self._client.get(url)
+        resp.raise_for_status()
         return Auth0UserData(**resp.json())
 
     def create_user(self, user: BiocommonsRegisterData) -> Auth0UserData:

--- a/routers/bpa_register.py
+++ b/routers/bpa_register.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 from httpx import HTTPStatusError
 from sqlmodel import Session
+from starlette.responses import JSONResponse
 
 from auth.ses import EmailService
 from auth0.client import Auth0Client, get_auth0_client
@@ -122,7 +123,7 @@ async def register_bpa_user(
             response = RegistrationErrorResponse(message="Username or email already in use")
         else:
             response = RegistrationErrorResponse(message=f"Auth0 error: {str(e.response.text)}")
-        return response
+        return JSONResponse(status_code=400, content=response.model_dump(mode="json"))
     # Unknown errors should return 500
     except Exception as e:
         raise HTTPException(

--- a/routers/bpa_register.py
+++ b/routers/bpa_register.py
@@ -1,6 +1,5 @@
 import logging
 from datetime import datetime, timezone
-from typing import Any, Dict
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 from httpx import HTTPStatusError
@@ -11,22 +10,29 @@ from auth0.client import Auth0Client, get_auth0_client
 from config import Settings, get_settings
 from db.models import BiocommonsUser, PlatformEnum
 from db.setup import get_db_session
+from routers.errors import RegistrationRoute
 from schemas.biocommons import Auth0UserData, BiocommonsRegisterData
-from schemas.bpa import BPARegistrationRequest
+from schemas.bpa import BPARegistrationRequest, BPARegistrationResponse
+from schemas.responses import RegistrationErrorResponse
 from schemas.service import Resource, Service
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(prefix="/bpa", tags=["bpa", "registration"])
+router = APIRouter(
+    prefix="/bpa",
+    tags=["bpa", "registration"],
+    # Overriding route class to handle registration errors
+    route_class=RegistrationRoute
+)
 
 
-def send_approval_email(registration: BPARegistrationRequest, bpa_resources: list):
+def send_approval_email(registration: BPARegistrationRequest, bpa_resources: list[Resource]):
     email_service = EmailService()
     approver_email = "aai-dev@biocommons.org.au"
     subject = "New BPA User Access Request"
 
     org_list_html = "".join(
-        f"<li>{res['name']} (ID: {res['id']})</li>" for res in bpa_resources
+        f"<li>{res.name} (ID: {res.id})</li>" for res in bpa_resources
     )
 
     body_html = f"""
@@ -61,14 +67,24 @@ def _get_bpa_resources(registration: BPARegistrationRequest, settings: Settings,
     return bpa_resources
 
 
+def _get_bpa_service_request(registration: BPARegistrationRequest, settings: Settings, update_time: datetime) -> Service:
+    bpa_resources = _get_bpa_resources(registration, settings, update_time)
+    return Service(
+        name="Bioplatforms Australia Data Portal",
+        id="bpa",
+        initial_request_time=update_time,
+        status="pending",
+        last_updated=update_time,
+        updated_by="system",
+        resources=bpa_resources,
+    )
+
 
 @router.post(
     "/register",
-    response_model=Dict[str, Any],
     responses={
-        400: {"description": "Bad Request - Validation error"},
-        409: {"description": "Conflict - User already exists"},
-        500: {"description": "Internal server error"},
+        200: {"model": BPARegistrationResponse},
+        400: {"model": RegistrationErrorResponse},
     },
 )
 async def register_bpa_user(
@@ -77,20 +93,10 @@ async def register_bpa_user(
     settings: Settings = Depends(get_settings),
     db_session: Session = Depends(get_db_session),
     auth0_client: Auth0Client = Depends(get_auth0_client)
-) -> Dict[str, Any]:
+):
     """Register a new BPA user with selected organization resources."""
     now = datetime.now(timezone.utc)
-
-    bpa_resources = _get_bpa_resources(registration, settings, update_time=now)
-    bpa_service = Service(
-        name="Bioplatforms Australia Data Portal",
-        id="bpa",
-        initial_request_time=now,
-        status="pending",
-        last_updated=now,
-        updated_by="system",
-        resources=bpa_resources,
-    )
+    bpa_service = _get_bpa_service_request(registration=registration, settings=settings, update_time=now)
 
     # Create Auth0 user data
     user_data = BiocommonsRegisterData.from_bpa_registration(
@@ -104,13 +110,20 @@ async def register_bpa_user(
         logger.info("Adding user to DB")
         _create_bpa_user_record(auth0_user_data, db_session)
 
-        if bpa_resources and settings.send_email:
-            background_tasks.add_task(send_approval_email, registration, bpa_resources)
+        if bpa_service.resources and settings.send_email:
+            background_tasks.add_task(send_approval_email, registration, bpa_resources=bpa_service.resources)
 
         return {"message": "User registered successfully", "user": auth0_user_data.model_dump(mode="json")}
 
+    # Return HTTP status errors as RegistrationErrorResponse
     except HTTPStatusError as e:
-        raise HTTPException(status_code=e.response.status_code, detail=e.response.text)
+        # Catch specific errors where possible and return a useful error message
+        if e.response.status_code == 409:
+            response = RegistrationErrorResponse(message="Username or email already in use")
+        else:
+            response = RegistrationErrorResponse(message=f"Auth0 error: {str(e.response.text)}")
+        return response
+    # Unknown errors should return 500
     except Exception as e:
         raise HTTPException(
             status_code=500, detail=f"Failed to register user: {str(e)}"

--- a/routers/bpa_register.py
+++ b/routers/bpa_register.py
@@ -13,8 +13,8 @@ from db.models import BiocommonsUser, PlatformEnum
 from db.setup import get_db_session
 from routers.errors import RegistrationRoute
 from schemas.biocommons import Auth0UserData, BiocommonsRegisterData
-from schemas.bpa import BPARegistrationRequest, BPARegistrationResponse
-from schemas.responses import RegistrationErrorResponse
+from schemas.bpa import BPARegistrationRequest
+from schemas.responses import RegistrationErrorResponse, RegistrationResponse
 from schemas.service import Resource, Service
 
 logger = logging.getLogger(__name__)
@@ -84,7 +84,7 @@ def _get_bpa_service_request(registration: BPARegistrationRequest, settings: Set
 @router.post(
     "/register",
     responses={
-        200: {"model": BPARegistrationResponse},
+        200: {"model": RegistrationResponse},
         400: {"model": RegistrationErrorResponse},
     },
 )

--- a/routers/errors.py
+++ b/routers/errors.py
@@ -1,0 +1,40 @@
+"""
+Custom error responses
+"""
+from typing import Callable
+
+from fastapi.encoders import jsonable_encoder
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+from fastapi.routing import APIRoute
+from starlette.requests import Request
+from starlette.responses import Response
+
+from schemas.responses import FieldError, RegistrationErrorResponse
+
+
+class RegistrationRoute(APIRoute):
+    def get_route_handler(self) -> Callable:
+        original_route_handler = super().get_route_handler()
+
+        async def custom_route_handler(request: Request) -> Response:
+            try:
+                return await original_route_handler(request)
+            except RequestValidationError as exc:
+                return handle_registration_error(exc)
+
+        return custom_route_handler
+
+
+def handle_registration_error(exc: RequestValidationError):
+    field_errors = []
+    for error in exc.errors():
+        loc, msg = error["loc"], error["msg"]
+        filtered_loc = loc[1:] if loc[0] in ("body", "query", "path") else loc
+        field_string = ".".join(filtered_loc)
+        field_errors.append(FieldError(field=field_string, message=msg))
+    response = RegistrationErrorResponse(
+        message="Invalid data submitted",
+        field_errors=field_errors,
+    )
+    return JSONResponse(status_code=400, content=jsonable_encoder(response))

--- a/routers/errors.py
+++ b/routers/errors.py
@@ -14,6 +14,10 @@ from schemas.responses import FieldError, RegistrationErrorResponse
 
 
 class RegistrationRoute(APIRoute):
+    """
+    Custom route class for registration requests, returns RegistrationErrorResponse
+    for validation errors.
+    """
     def get_route_handler(self) -> Callable:
         original_route_handler = super().get_route_handler()
 

--- a/routers/galaxy_register.py
+++ b/routers/galaxy_register.py
@@ -17,7 +17,11 @@ from register.tokens import create_registration_token, verify_registration_token
 from routers.errors import RegistrationRoute
 from schemas.biocommons import Auth0UserData, BiocommonsRegisterData
 from schemas.galaxy import GalaxyRegistrationData
-from schemas.responses import FieldError, RegistrationErrorResponse
+from schemas.responses import (
+    FieldError,
+    RegistrationErrorResponse,
+    RegistrationResponse,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -33,7 +37,13 @@ async def get_registration_token(settings: Settings = Depends(get_settings)):
     return {"token": create_registration_token(settings)}
 
 
-@router.post("/register")
+@router.post(
+    "/register",
+    responses={
+        200: {"model": RegistrationResponse},
+        400: {"model": RegistrationErrorResponse},
+    }
+)
 def register(
         registration_data: GalaxyRegistrationData,
         settings: Annotated[Settings, Depends(get_settings)],

--- a/schemas/bpa.py
+++ b/schemas/bpa.py
@@ -2,7 +2,7 @@ from typing import Dict
 
 from pydantic import BaseModel, EmailStr
 
-from schemas.biocommons import BiocommonsPassword, BiocommonsUsername
+from schemas.biocommons import Auth0UserData, BiocommonsPassword, BiocommonsUsername
 
 
 class BPARegistrationRequest(BaseModel):
@@ -12,3 +12,8 @@ class BPARegistrationRequest(BaseModel):
     reason: str
     password: BiocommonsPassword
     organizations: Dict[str, bool]
+
+
+class BPARegistrationResponse(BaseModel):
+    message: str
+    user: Auth0UserData

--- a/schemas/bpa.py
+++ b/schemas/bpa.py
@@ -2,7 +2,7 @@ from typing import Dict
 
 from pydantic import BaseModel, EmailStr
 
-from schemas.biocommons import Auth0UserData, BiocommonsPassword, BiocommonsUsername
+from schemas.biocommons import BiocommonsPassword, BiocommonsUsername
 
 
 class BPARegistrationRequest(BaseModel):
@@ -12,8 +12,3 @@ class BPARegistrationRequest(BaseModel):
     reason: str
     password: BiocommonsPassword
     organizations: Dict[str, bool]
-
-
-class BPARegistrationResponse(BaseModel):
-    message: str
-    user: Auth0UserData

--- a/schemas/responses.py
+++ b/schemas/responses.py
@@ -12,4 +12,4 @@ class RegistrationErrorResponse(BaseModel):
     errors for individual fields where possible
     """
     message: str = Field(description="Overall error message")
-    field_errors: list[FieldError] = []
+    field_errors: list[FieldError] = Field(default_factory=list)

--- a/schemas/responses.py
+++ b/schemas/responses.py
@@ -1,5 +1,7 @@
 from pydantic import BaseModel, Field
 
+from schemas.biocommons import Auth0UserData
+
 
 class FieldError(BaseModel):
     field: str
@@ -13,3 +15,8 @@ class RegistrationErrorResponse(BaseModel):
     """
     message: str = Field(description="Overall error message")
     field_errors: list[FieldError] = Field(default_factory=list)
+
+
+class RegistrationResponse(BaseModel):
+    message: str
+    user: Auth0UserData

--- a/schemas/responses.py
+++ b/schemas/responses.py
@@ -1,0 +1,15 @@
+from pydantic import BaseModel, Field
+
+
+class FieldError(BaseModel):
+    field: str
+    message: str
+
+
+class RegistrationErrorResponse(BaseModel):
+    """
+    Error response for registration requests that specifies
+    errors for individual fields where possible
+    """
+    message: str = Field(description="Overall error message")
+    field_errors: list[FieldError] = []

--- a/tests/datagen.py
+++ b/tests/datagen.py
@@ -38,6 +38,10 @@ class BiocommonsRegisterDataFactory(ModelFactory[BiocommonsRegisterData]):
     def connection(cls) -> str:
         return "Username-Password-Authentication"
 
+
+class BiocommonsRegistrationRequestFactory(ModelFactory[BiocommonsRegistrationRequest]): ...
+
+
 class SessionUserFactory(ModelFactory[SessionUser]): ...
 
 

--- a/tests/test_biocommons_register.py
+++ b/tests/test_biocommons_register.py
@@ -2,7 +2,10 @@ import pytest
 
 from schemas.biocommons import BiocommonsRegisterData
 from schemas.biocommons_register import BiocommonsRegistrationRequest
-from tests.datagen import Auth0UserDataFactory
+from tests.datagen import (
+    Auth0UserDataFactory,
+    BiocommonsRegistrationRequestFactory,
+)
 
 
 def test_biocommons_registration_data_excludes_null_user_metadata():
@@ -35,6 +38,17 @@ def test_biocommons_registration_data_excludes_null_user_metadata():
     assert app_metadata["registration_from"] == "biocommons"
     assert app_metadata.get("services", []) == []
     assert app_metadata.get("groups", []) == []
+
+
+def test_biocommons_registration_invalid_field(test_client):
+    user_data = BiocommonsRegistrationRequestFactory.build()
+    user_data.email = "invalid-email"
+    response = test_client.post("/biocommons/register", json=user_data.model_dump(mode="json"))
+
+    assert response.status_code == 400
+    assert response.json()["message"] == "Invalid data submitted"
+    field_errors = response.json()["field_errors"]
+    assert field_errors[0]["field"] == "email"
 
 
 def test_biocommons_registration_tsi_bundle():

--- a/tests/test_biocommons_register.py
+++ b/tests/test_biocommons_register.py
@@ -328,8 +328,8 @@ def test_biocommons_registration_auth0_conflict_error(
 
     response = test_client.post("/biocommons/register", json=registration_data)
 
-    assert response.status_code == 409
-    assert response.json()["detail"] == "User already exists"
+    assert response.status_code == 400
+    assert response.json()["message"] == "Username or email already in use"
 
 
 def test_biocommons_registration_missing_group_error(test_client, mock_auth0_client):


### PR DESCRIPTION
## Description

[AAI-289](https://biocloud.atlassian.net/browse/AAI-289): add an error response for registration requests that's easier to use in the frontend. Where possible, the response should specify which fields have errors and individual error messages for them.

## Changes

- Add a `RegistrationErrorResponse` that is returned (with status code 400) for registration errors.
- Use `RegistrationErrorResponse` in registration endpoints
- Add a custom route handler so we can override FastAPI's default validation to raise the error in the format we want
- Update tests

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit / integration tests that prove my fix is effective or that my feature works
- [x] I have run all tests locally and they pass
- [x] I have updated the documentation (if applicable)

## How to Test Manually (if necessary)

Run `uv run pytest`


[AAI-289]: https://biocloud.atlassian.net/browse/AAI-289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ