### PR TITLE
Allow registration to continue if Galaxy API fails to connect

### DIFF
--- a/galaxy/client.py
+++ b/galaxy/client.py
@@ -29,6 +29,7 @@ class GalaxyClient:
         for an exact match.
         """
         resp = self.client.get("/api/users", params={"f_name": username})
+        resp.raise_for_status()
         returned_users = [GalaxyUserModel(**u) for u in resp.json()]
         for user in returned_users:
             if user.username == username:


### PR DESCRIPTION
Another quick fix: we don't want registration to fail if the Galaxy API can't be contacted - does increase the risk of duplicate usernames but it's more important that registration works and isn't dependent on our flaky Galaxy test instance.
