### PR TITLE
Omit None when submitting registration data to Auth0 + tests

### DIFF
--- a/auth0/client.py
+++ b/auth0/client.py
@@ -96,7 +96,8 @@ class Auth0Client:
 
     def create_user(self, user: BiocommonsRegisterData) -> Auth0UserData:
         url = f"https://{self.domain}/api/v2/users"
-        resp = self._client.post(url, json=user.model_dump(mode="json"))
+        # Exclude None values to avoid validation errors.
+        resp = self._client.post(url, json=user.model_dump(mode="json", exclude_none=True))
         resp.raise_for_status()
         return Auth0UserData(**resp.json())
 

--- a/tests/datagen.py
+++ b/tests/datagen.py
@@ -4,7 +4,11 @@ from string import ascii_letters, digits
 from polyfactory.decorators import post_generated
 from polyfactory.factories.pydantic_factory import ModelFactory
 
-from schemas.biocommons import Auth0UserData, BiocommonsAppMetadata
+from schemas.biocommons import (
+    Auth0UserData,
+    BiocommonsAppMetadata,
+    BiocommonsRegisterData,
+)
 from schemas.biocommons_register import BiocommonsRegistrationRequest
 from schemas.bpa import BPARegistrationRequest
 from schemas.galaxy import GalaxyRegistrationData
@@ -27,6 +31,12 @@ class AccessTokenPayloadFactory(ModelFactory[AccessTokenPayload]):
     def sub(cls) -> str:
         return random_auth0_id()
 
+
+class BiocommonsRegisterDataFactory(ModelFactory[BiocommonsRegisterData]):
+
+    @classmethod
+    def connection(cls) -> str:
+        return "Username-Password-Authentication"
 
 class SessionUserFactory(ModelFactory[SessionUser]): ...
 


### PR DESCRIPTION
This got missed when making changes to user metadata recently (I think because it only impacts the Galaxy only registration). Make sure we leave out `None`/`null` values when submitting data to Auth0.
