### PR TITLE
Fix group creation

### DIFF
--- a/routers/biocommons_groups.py
+++ b/routers/biocommons_groups.py
@@ -45,7 +45,8 @@ def create_group(
     """
     # Check group exists in Auth0
     try:
-        auth0_client.get_role_by_name(group_info.name)
+        # Note: our "group ids" are actually the Auth0 role names
+        auth0_client.get_role_by_name(name=group_info.group_id)
     except ValueError:
         raise HTTPException(
             status_code=HTTPStatus.NOT_FOUND,

--- a/tests/biocommons/test_api.py
+++ b/tests/biocommons/test_api.py
@@ -47,9 +47,10 @@ def test_create_group(test_client, as_admin_user, test_auth0_client, test_db_ses
             "admin_roles": [admin_role.name]
         }
     )
-    print(resp.json())
     assert resp.status_code == 200
     assert route.called
+    role_lookup = route.calls[0].request.url.params
+    assert role_lookup["name_filter"] == "biocommons/group/tsi"
     group_from_db = test_db_session.exec(select(BiocommonsGroup).where(BiocommonsGroup.group_id == "biocommons/group/tsi")).one()
     assert group_from_db.group_id == "biocommons/group/tsi"
     assert group_from_db.name == "Threatened Species Initiative"


### PR DESCRIPTION
We were looking up the wrong field when checking that the corresponding role was in Auth0 - have added a test for it.
