### PR TITLE
implement is-admin endpoint

### DIFF
--- a/routers/user.py
+++ b/routers/user.py
@@ -81,6 +81,15 @@ async def get_services(
     return {"services": user_data.app_metadata.services}
 
 
+@router.get("/is-admin")
+async def check_is_admin(
+    user: Annotated[SessionUser, Depends(get_current_user)],
+    settings: Annotated[Settings, Depends(get_settings)],
+):
+    """Check if the current user has admin privileges."""
+    return {"is_admin": user.is_admin(settings)}
+
+
 @router.get("/services/approved", response_model=Dict[str, List[Service]])
 async def get_approved_services(
     user: Annotated[SessionUser, Depends(get_current_user)],

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -494,7 +494,6 @@ def test_check_is_admin_with_admin_role(test_client, mock_settings, mocker):
 
     mocker.patch("auth.validator.verify_jwt", return_value=admin_token)
     mocker.patch("auth.validator.get_current_user", return_value=admin_user)
-    mocker.patch("auth.management.get_management_token", return_value="mock_token")
 
     response = test_client.get(
         "/me/is-admin",
@@ -516,7 +515,6 @@ def test_check_is_admin_with_non_admin_role(test_client, mock_settings, mocker):
 
     mocker.patch("auth.validator.verify_jwt", return_value=user_token)
     mocker.patch("auth.validator.get_current_user", return_value=user)
-    mocker.patch("auth.management.get_management_token", return_value="mock_token")
 
     response = test_client.get(
         "/me/is-admin",

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -481,3 +481,53 @@ def test_request_resource_invalid_service(
     )
     assert response.status_code == 404
     assert response.json()["detail"] == "Service with ID non-existent-service not found"
+
+
+def test_check_is_admin_with_admin_role(test_client, mock_settings, mocker):
+    """Test that admin check returns True for users with admin role"""
+    from tests.datagen import SessionUserFactory
+
+    admin_token = AccessTokenPayloadFactory.build(
+        biocommons_roles=["Admin"]
+    )
+    admin_user = SessionUserFactory.build(access_token=admin_token)
+
+    mocker.patch("auth.validator.verify_jwt", return_value=admin_token)
+    mocker.patch("auth.validator.get_current_user", return_value=admin_user)
+    mocker.patch("auth.management.get_management_token", return_value="mock_token")
+
+    response = test_client.get(
+        "/me/is-admin",
+        headers={"Authorization": "Bearer valid_token"}
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"is_admin": True}
+
+
+def test_check_is_admin_with_non_admin_role(test_client, mock_settings, mocker):
+    """Test that admin check returns False for users without admin role"""
+    from tests.datagen import SessionUserFactory
+
+    user_token = AccessTokenPayloadFactory.build(
+        biocommons_roles=["User"]
+    )
+    user = SessionUserFactory.build(access_token=user_token)
+
+    mocker.patch("auth.validator.verify_jwt", return_value=user_token)
+    mocker.patch("auth.validator.get_current_user", return_value=user)
+    mocker.patch("auth.management.get_management_token", return_value="mock_token")
+
+    response = test_client.get(
+        "/me/is-admin",
+        headers={"Authorization": "Bearer valid_token"}
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"is_admin": False}
+
+
+def test_check_is_admin_without_authentication(test_client):
+    """Test that admin check requires authentication"""
+    response = test_client.get("/me/is-admin")
+    assert response.status_code == 401


### PR DESCRIPTION
## Description

[AAI-273](https://biocloud.atlassian.net/jira/software/c/projects/AAI/boards/53?assignee=63f30233526117e1514b222b&selectedIssue=AAI-273): Determine if user is admin in aai-backend

## Changes

- Implement is-admin endpoint for the front-end to check if the current user is an admin or not
- Added tests

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit / integration tests that prove my fix is effective or that my feature works
- [x] I have run all tests locally and they pass
- [x] I have updated the documentation (if applicable)


[AAI-273]: https://biocloud.atlassian.net/browse/AAI-273?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ