### PR TITLE
Enable getting autoregister organizations from BPA

### DIFF
--- a/config.py
+++ b/config.py
@@ -40,6 +40,11 @@ class Settings(BaseSettings):
         "bpa-wheat-pathogens-transcript": "Wheat Pathogens Transcript",
     }
 
+    ckan_base_url: str
+    ckan_api_key: Optional[str] = None
+    ckan_timeout_s: float = 10.0
+    ckan_verify_ssl: bool = True
+
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 
 

--- a/services/ckan_client.py
+++ b/services/ckan_client.py
@@ -1,0 +1,63 @@
+__all__ = ["CKANClient", "get_ckan_client"]
+
+from typing import Optional
+
+import httpx
+from fastapi import Depends
+from pydantic import BaseModel
+
+from config import Settings, get_settings
+
+
+class OrgOut(BaseModel):
+    """
+    Minimal org payload for the portal dropdown.
+    """
+    id: str
+    name: str
+    title: str
+
+
+class CKANClient:
+    """
+    Tiny client for CKAN Action API calls used by aai-backend.
+    """
+
+    ACTION_AUTOREGISTER_ORGS = "/api/3/action/ytp_request_autoregister_organization_list"
+
+    def __init__(self, base_url: str, api_key: Optional[str], timeout_s: float, verify_ssl: bool):
+        self.base_url = base_url.rstrip("/")
+        self.api_key = api_key
+        headers = {}
+        if api_key:
+            # CKAN expects the API key in the Authorization header (no Bearer prefix)
+            headers["Authorization"] = api_key
+        # Mirror the style of Auth0Client: keep a single sync client instance
+        self._client = httpx.Client(headers=headers, timeout=timeout_s, verify=verify_ssl)
+
+    def get_autoregister_organizations(self) -> list[OrgOut]:
+        """
+        Calls the CKAN action exposed by ckanext-ytp-request to fetch the
+        list of orgs eligible for auto-registration.
+        """
+        url = f"{self.base_url}{self.ACTION_AUTOREGISTER_ORGS}"
+        resp = self._client.post(url, json={})
+        resp.raise_for_status()
+        payload = resp.json()
+        if not payload.get("success"):
+            # CKAN Action API returns {"success": false, "error": {...}} on failure
+            raise ValueError("CKAN action reported success=false")
+        result = payload.get("result") or []
+        return [OrgOut(**item) for item in result]
+
+
+def get_ckan_client(settings: Settings = Depends(get_settings)) -> CKANClient:
+    """
+    FastAPI dependency that wires CKAN config from Settings.
+    """
+    return CKANClient(
+        base_url=settings.ckan_base_url,
+        api_key=settings.ckan_api_key,
+        timeout_s=settings.ckan_timeout_s,
+        verify_ssl=settings.ckan_verify_ssl,
+    )

--- a/tests/test_bpa_register_autoregister_list.py
+++ b/tests/test_bpa_register_autoregister_list.py
@@ -1,0 +1,43 @@
+import types
+
+import bpa_register
+
+
+class _Org:
+    def __init__(self, name: str, title: str):
+        self.name = name
+        self.title = title
+
+
+class _OKCkanClient:
+    def get_autoregister_organizations(self):
+        return [_Org(name="bpa", title="Bioplatforms Australia"),
+                _Org(name="fungi", title="Fungi Functional 'Omics")]
+
+
+class _FailingCkanClient:
+    def get_autoregister_organizations(self):
+        raise RuntimeError("ckan is down")
+
+
+def test_get_bpa_autoregister_list_prefers_ckan():
+    ckan = _OKCkanClient()
+    settings = types.SimpleNamespace(
+        # Would be ignored since CKAN succeeds:
+        organizations={"legacy": "Legacy Title"}
+    )
+    mapping = bpa_register._get_bpa_autoregister_list(ckan, settings)
+    assert mapping == {
+        "bpa": "Bioplatforms Australia",
+        "fungi": "Fungi Functional 'Omics",
+    }
+
+
+def test_get_bpa_autoregister_list_fallback_on_error():
+    ckan = _FailingCkanClient()
+    settings = types.SimpleNamespace(
+        organizations={"legacy": "Legacy Title", "bpa": "Bioplatforms Australia"}
+    )
+    mapping = bpa_register._get_bpa_autoregister_list(ckan, settings)
+    # Falls back entirely to the static settings
+    assert mapping == settings.organizations

--- a/tests/test_ckan_client.py
+++ b/tests/test_ckan_client.py
@@ -1,0 +1,83 @@
+import json
+import types
+import pytest
+
+import ckan_client
+
+
+class _FakeResponse:
+    def __init__(self, data: dict, status_code: int = 200):
+        self._data = data
+        self.status_code = status_code
+        self.text = json.dumps(data)
+
+    def json(self):
+        return self._data
+
+    def raise_for_status(self):
+        # Simulate httpx behavior: raise for 4xx/5xx
+        if self.status_code >= 400:
+            raise ckan_client.httpx.HTTPStatusError(
+                "error", request=None, response=self
+            )
+
+
+class _FakeHttpxClientOK:
+    """httpx.Client mock that returns success=true with one org."""
+
+    def __init__(self, **kwargs):
+        pass
+
+    def post(self, url, json=None):
+        # Ensure we're calling the expected CKAN action path
+        assert url.endswith(ckan_client.CKANClient.ACTION_AUTOREGISTER_ORGS)
+        return _FakeResponse(
+            {
+                "success": True,
+                "result": [{"id": "1", "name": "bpa", "title": "Bioplatforms Australia"}],
+            }
+        )
+
+
+class _FakeHttpxClientSuccessFalse:
+    """httpx.Client mock that returns success=false (CKAN action error)."""
+
+    def __init__(self, **kwargs):
+        pass
+
+    def post(self, url, json=None):
+        return _FakeResponse({"success": False, "error": {"message": "boom"}})
+
+
+def test_ckan_client_success(monkeypatch):
+    # Replace httpx.Client with our fake
+    monkeypatch.setattr(
+        ckan_client, "httpx", types.SimpleNamespace(Client=_FakeHttpxClientOK)
+    )
+    cli = ckan_client.CKANClient(
+        base_url="https://ckan.example.org",
+        api_key=None,
+        timeout_s=5,
+        verify_ssl=True,
+    )
+
+    orgs = cli.get_autoregister_organizations()
+    assert len(orgs) == 1
+    assert orgs[0].id == "1"
+    assert orgs[0].name == "bpa"
+    assert orgs[0].title == "Bioplatforms Australia"
+
+
+def test_ckan_client_success_false_raises(monkeypatch):
+    monkeypatch.setattr(
+        ckan_client, "httpx", types.SimpleNamespace(Client=_FakeHttpxClientSuccessFalse)
+    )
+    cli = ckan_client.CKANClient(
+        base_url="https://ckan.example.org",
+        api_key="secret",
+        timeout_s=5,
+        verify_ssl=True,
+    )
+
+    with pytest.raises(ValueError):
+        _ = cli.get_autoregister_organizations()


### PR DESCRIPTION
In this pull request, we enable the capability to get the autoregister organizations from BPA Data Portal.

[AAI-213](https://biocloud.atlassian.net/browse/AAI-213): Expose an API endpoint in the aai-backend that returns the list of BPA Data Portal organizations

## Changes

- Add `services/ckan_client.py`
- Add ckan related configs in `config.py`
- Add related unit tests
- Add `_get_bpa_autoregister_list()` - this will be used in aai-portal.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit / integration tests that prove my fix is effective or that my feature works
- [x] I have run all tests locally and they pass
- [x] I have updated the documentation (if applicable)

## How to Test Manually (if necessary)

All new unit tests shall pass.

[AAI-213]: https://biocloud.atlassian.net/browse/AAI-213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ