### PR TITLE
AAI-304 user details endpoint to combine Auth0 and backend user data

### DIFF
--- a/db/models.py
+++ b/db/models.py
@@ -1,6 +1,5 @@
 import uuid
 from datetime import datetime, timezone
-from enum import Enum
 from typing import Self
 
 from pydantic import AwareDatetime
@@ -8,21 +7,16 @@ from sqlalchemy import UniqueConstraint
 from sqlmodel import DateTime, Field, Relationship, Session, select
 from sqlmodel import Enum as DbEnum
 
+import schemas
 from auth0.client import Auth0Client
 from db.core import BaseModel
-from schemas.biocommons import Auth0UserData
+from db.types import (
+    ApprovalStatusEnum,
+    GroupMembershipData,
+    PlatformEnum,
+    PlatformMembershipData,
+)
 from schemas.user import SessionUser
-
-
-class ApprovalStatusEnum(str, Enum):
-    APPROVED = "approved"
-    PENDING = "pending"
-    REVOKED = "revoked"
-
-
-class PlatformEnum(str, Enum):
-    GALAXY = "galaxy"
-    BPA_DATA_PORTAL = "bpa_data_portal"
 
 
 class BiocommonsUser(BaseModel, table=True):
@@ -55,7 +49,7 @@ class BiocommonsUser(BaseModel, table=True):
         return cls.from_auth0_data(user_data)
 
     @classmethod
-    def from_auth0_data(cls, data: Auth0UserData) -> Self:
+    def from_auth0_data(cls, data: 'schemas.biocommons.Auth0UserData') -> Self:
         """
         Create a new BiocommonsUser object from Auth0 user data (no API call).
         """
@@ -146,6 +140,22 @@ class PlatformMembership(BaseModel, table=True):
         )
         session.add(history)
         return history
+
+    def get_data(self) -> PlatformMembershipData:
+        """
+        Get a data model for this membership, suitable for returning to the frontend.
+        """
+        if self.updated_by is not None:
+            updated_by = self.updated_by.email
+        else:
+            updated_by = '(automatic)'
+        return PlatformMembershipData(
+            id=self.id,
+            platform_id=self.platform_id,
+            user_id=self.user_id,
+            approval_status=self.approval_status,
+            updated_by=updated_by,
+        )
 
 
 class PlatformMembershipHistory(BaseModel, table=True):
@@ -252,6 +262,22 @@ class GroupMembership(BaseModel, table=True):
         role = auth0_client.get_role_by_name(self.group_id)
         auth0_client.add_roles_to_user(user_id=self.user_id, role_id=role.id)
         return True
+
+    def get_data(self) -> GroupMembershipData:
+        """
+        Get a data model for this membership, suitable for returning to the frontend.
+        """
+        if self.updated_by is not None:
+            updated_by = self.updated_by.email
+        else:
+            updated_by = '(automatic)'
+        return GroupMembershipData(
+            id=self.id,
+            group_id=self.group_id,
+            group_name=self.group.name,
+            approval_status=self.approval_status,
+            updated_by=updated_by,
+        )
 
 
 class GroupMembershipHistory(BaseModel, table=True):

--- a/db/types.py
+++ b/db/types.py
@@ -1,0 +1,39 @@
+"""
+Shared types/enums used by the database.
+
+Useful to keep them here rather than in models.py to
+avoid circular imports.
+"""
+import uuid
+from enum import Enum
+
+from pydantic import BaseModel
+
+
+class ApprovalStatusEnum(str, Enum):
+    APPROVED = "approved"
+    PENDING = "pending"
+    REVOKED = "revoked"
+
+
+class PlatformEnum(str, Enum):
+    GALAXY = "galaxy"
+    BPA_DATA_PORTAL = "bpa_data_portal"
+
+
+class PlatformMembershipData(BaseModel):
+    """Data model for platform membership, when returned from the API"""
+    id: uuid.UUID
+    platform_id: PlatformEnum
+    user_id: str
+    approval_status: ApprovalStatusEnum
+    updated_by: str
+
+
+class GroupMembershipData(BaseModel):
+    """Data model for group membership, when returned from the API"""
+    id: uuid.UUID
+    group_id: str
+    group_name: str
+    approval_status: ApprovalStatusEnum
+    updated_by: str

--- a/routers/admin.py
+++ b/routers/admin.py
@@ -5,11 +5,13 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Path
 from fastapi.params import Query
 from pydantic import BaseModel, ValidationError
+from sqlmodel import Session
 
 from auth.validator import get_current_user, user_is_admin
 from auth0.client import Auth0Client, get_auth0_client
+from db.setup import get_db_session
 from routers.user import update_user_metadata
-from schemas.biocommons import Auth0UserData
+from schemas.biocommons import Auth0UserData, Auth0UserDataWithMemberships
 from schemas.user import SessionUser
 
 logger = logging.getLogger('uvicorn.error')
@@ -81,6 +83,25 @@ def get_revoked_users(client: Annotated[Auth0Client, Depends(get_auth0_client)],
 def get_user(user_id: Annotated[str, UserIdParam],
              client: Annotated[Auth0Client, Depends(get_auth0_client)]):
     return client.get_user(user_id)
+
+
+@router.get("/users/{user_id}/details",
+            response_model=Auth0UserDataWithMemberships)
+def get_user_details(user_id: Annotated[str, UserIdParam],
+                     client: Annotated[Auth0Client, Depends(get_auth0_client)],
+                     db_session: Annotated[Session, Depends(get_db_session)]):
+    """
+    Get user data from Auth0, along with group and platform membership information
+    from our user DB.
+    """
+    user = client.get_user(user_id)
+    from db.models import BiocommonsUser
+    db_user = db_session.get_one(BiocommonsUser, user_id)
+    details = Auth0UserDataWithMemberships.from_auth0_data(
+        auth0_data=user,
+        db_data=db_user,
+    )
+    return details
 
 
 @router.post("/users/{user_id}/verification-email/resend")


### PR DESCRIPTION
## Description

[AAI-304](https://biocloud.atlassian.net/browse/AAI-304): want to get both Auth0 data and data from our database to display on individual user details pages.

## Changes

- New endpoint to give combined user details


## Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit / integration tests that prove my fix is effective or that my feature works
- [ ] I have run all tests locally and they pass
- [ ] I have updated the documentation (if applicable)

## How to Test Manually (if necessary)

Run `uv run pytest`
