### PR TITLE
AAI-352: Remove orgs from bpa registration page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,3 +174,6 @@ cython_debug/
 .pypirc
 
 .vscode/
+
+# Local database file
+database.db

--- a/routers/bpa_register.py
+++ b/routers/bpa_register.py
@@ -15,7 +15,7 @@ from routers.errors import RegistrationRoute
 from schemas.biocommons import Auth0UserData, BiocommonsRegisterData
 from schemas.bpa import BPARegistrationRequest
 from schemas.responses import RegistrationErrorResponse, RegistrationResponse
-from schemas.service import Resource, Service
+from schemas.service import Service
 
 logger = logging.getLogger(__name__)
 
@@ -27,49 +27,22 @@ router = APIRouter(
 )
 
 
-def send_approval_email(registration: BPARegistrationRequest, bpa_resources: list[Resource]):
+def send_approval_email(registration: BPARegistrationRequest):
     email_service = EmailService()
     approver_email = "aai-dev@biocommons.org.au"
     subject = "New BPA User Access Request"
 
-    org_list_html = "".join(
-        f"<li>{res.name} (ID: {res.id})</li>" for res in bpa_resources
-    )
-
     body_html = f"""
-        <p>A new user has requested access to one or more organizations in the BPA service.</p>
+        <p>A new user has requested access to the Bioplatforms Australia Data Portal service.</p>
         <p><strong>User:</strong> {registration.fullname} ({registration.email})</p>
-        <p><strong>Requested access to:</strong></p>
-        <ul>{org_list_html}</ul>
-        <p>Please <a href='https://aaiportal.test.biocommons.org.au/requests'>log into the AAI Admin Portal</a> to review and approve access.</p>
+        <p><strong>Reason:</strong> {registration.reason}</p>
+        <p>Please <a href='https://aaiportal.test.biocommons.org.au/requests'>log into the AAI Admin Portal</a> to review access.</p>
     """
 
     email_service.send(approver_email, subject, body_html)
 
 
-def _get_bpa_resources(registration: BPARegistrationRequest, settings: Settings, update_time: datetime) -> list[Resource]:
-    bpa_resources = []
-    for org_id, is_selected in registration.organizations.items():
-        if not is_selected:
-            continue
-        if org_id not in settings.organizations:
-            raise HTTPException(
-                status_code=400, detail=f"Invalid organization ID: {org_id}"
-            )
-        resource = Resource(
-            id=org_id,
-            name=settings.organizations[org_id],
-            status="pending",
-            last_updated=update_time,
-            initial_request_time=update_time,
-            updated_by="system",
-        ).model_dump(mode="json")
-        bpa_resources.append(resource)
-    return bpa_resources
-
-
 def _get_bpa_service_request(registration: BPARegistrationRequest, settings: Settings, update_time: datetime) -> Service:
-    bpa_resources = _get_bpa_resources(registration, settings, update_time)
     return Service(
         name="Bioplatforms Australia Data Portal",
         id="bpa",
@@ -77,7 +50,6 @@ def _get_bpa_service_request(registration: BPARegistrationRequest, settings: Set
         status="pending",
         last_updated=update_time,
         updated_by="system",
-        resources=bpa_resources,
     )
 
 
@@ -95,7 +67,7 @@ async def register_bpa_user(
     db_session: Session = Depends(get_db_session),
     auth0_client: Auth0Client = Depends(get_auth0_client)
 ):
-    """Register a new BPA user with selected organization resources."""
+    """Register a new BPA user."""
     now = datetime.now(timezone.utc)
     bpa_service = _get_bpa_service_request(registration=registration, settings=settings, update_time=now)
 
@@ -111,8 +83,8 @@ async def register_bpa_user(
         logger.info("Adding user to DB")
         _create_bpa_user_record(auth0_user_data, db_session)
 
-        if bpa_service.resources and settings.send_email:
-            background_tasks.add_task(send_approval_email, registration, bpa_resources=bpa_service.resources)
+        if settings.send_email:
+            background_tasks.add_task(send_approval_email, registration)
 
         return {"message": "User registered successfully", "user": auth0_user_data.model_dump(mode="json")}
 

--- a/schemas/bpa.py
+++ b/schemas/bpa.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 from pydantic import BaseModel, EmailStr
 
 from schemas.biocommons import BiocommonsPassword, BiocommonsUsername
@@ -11,4 +9,3 @@ class BPARegistrationRequest(BaseModel):
     email: EmailStr
     reason: str
     password: BiocommonsPassword
-    organizations: Dict[str, bool]

--- a/tests/datagen.py
+++ b/tests/datagen.py
@@ -109,15 +109,6 @@ class GalaxyRegistrationDataFactory(ModelFactory[GalaxyRegistrationData]):
 class BPARegistrationDataFactory(ModelFactory[BPARegistrationRequest]):
     """Factory for generating BPA registration test data."""
 
-    @classmethod
-    def get_default_organizations(cls) -> dict:
-        """Default organization selection."""
-        return {
-            "bpa-bioinformatics-workshop": True,
-            "cipps": False,
-            "ausarg": True,
-        }
-
     password = BiocommonsProviders.biocommons_password
     username = BiocommonsProviders.biocommons_username
 


### PR DESCRIPTION


## Description

[AAI-352](https://biocloud.atlassian.net/jira/software/c/projects/AAI/boards/53?assignee=63f30233526117e1514b222b&selectedIssue=AAI-352): Remove orgs from bpa registration page & update deployment configuration

## Changes

- Remove orgs from bpa registration page
- Added local databse.db to gitignore
- Updated relevant tests

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit / integration tests that prove my fix is effective or that my feature works
- [x] I have run all tests locally and they pass
- [x] I have updated the documentation (if applicable)
