### PR TITLE
AAI-326 add scheduler/job queue to automated deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,20 @@ and run the migrations:
 uv run alembic upgrade head
 ```
 
+# Job scheduler
+
+We use the `apscheduler` library to schedule recurring jobs. Currently
+this is used to synchronize user information from Auth0 to the AAI
+database. You can run the job scheduler locally using:
+
+```shell
+uv run python run_scheduler.py
+```
+
+Note that for small jobs that run on-demand, e.g. sending a notification email when a user
+signs up, you can use FastAPI's built-in [background tasks](https://fastapi.tiangolo.com/tutorial/background-tasks/)
+within the FastAPI app, instead of using the dedicated job scheduler.
+
 # Deployment
 
 Currently the service is deployed to AWS via the CDK scripts in `deploy/`,
@@ -112,3 +126,8 @@ and updated on each commit to `main`.
 
 Secrets/configuration variables for the deployment are stored in the
 GitHub Secrets for the repository.
+
+The service deploys two containers (which both use the same image/Python environment):
+
+* The FastAPI app
+* The `apscheduler` job scheduler

--- a/deploy/aai_backend_deploy/aai_backend_deploy_stack.py
+++ b/deploy/aai_backend_deploy/aai_backend_deploy_stack.py
@@ -60,9 +60,9 @@ class AaiBackendDeployStack(Stack):
 
         # Task definition for Fargate
         task_definition = ecs.FargateTaskDefinition(self, "AaiBackendTaskDef",
-                                                    memory_limit_mib=1024,
-                                                    cpu=512)
-        # Allow executing comands in the ECS container
+                                                    memory_limit_mib=2048,
+                                                    cpu=1024)
+        # Allow executing commands in the ECS container
         task_definition.task_role.add_managed_policy(
             iam.ManagedPolicy.from_aws_managed_policy_name("AmazonSSMManagedInstanceCore")
         )

--- a/deploy/aai_backend_deploy/aai_backend_deploy_stack.py
+++ b/deploy/aai_backend_deploy/aai_backend_deploy_stack.py
@@ -131,4 +131,12 @@ class AaiBackendDeployStack(Stack):
 
         service.target_group.configure_health_check(path="/", healthy_http_codes="200-399")
 
+        # Output relevant ARNs and IDs
         CfnOutput(self, "LoadBalancerDNS", value=service.load_balancer.load_balancer_dns_name)
+        CfnOutput(self, "ServiceArn", value=service.service.service_arn)
+        CfnOutput(self, "ServiceName", value=service.service.service_name)
+        CfnOutput(self, "ClusterArn", value=cluster.cluster_arn)
+        CfnOutput(self, "ClusterName", value=cluster.cluster_name)
+        CfnOutput(self, "TaskDefinitionArn", value=task_definition.task_definition_arn)
+        CfnOutput(self, "TaskDefinitionFamily", value=task_definition.family)
+        CfnOutput(self, "LoadBalancerArn", value=service.load_balancer.load_balancer_arn)


### PR DESCRIPTION
## Description

[AAI-326](https://biocloud.atlassian.net/browse/AAI-326): add a container that runs the job scheduler to the automated CDK deployment. We can reuse the existing docker image for this, we just run it with a different command.

## Changes

- Add a container to the deployment that runs the job queue/scheduler
- Increase CPU/memory for the service since we're running 2 containers now

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit / integration tests that prove my fix is effective or that my feature works
- [ ] I have run all tests locally and they pass
- [x] I have updated the documentation (if applicable)

## How to Test Manually (if necessary)

Difficult to test locally as it requires access to AWS secrets etc. - probably need to merge this and check that the deployment succeeds in GitHub Actions.


[AAI-326]: https://biocloud.atlassian.net/browse/AAI-326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ