### PR TITLE
read JWT and CORS from os.env.

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,3 +1,4 @@
+import os
 from contextlib import asynccontextmanager
 
 from dotenv import dotenv_values
@@ -23,10 +24,18 @@ from routers import (
 #   and load them via config.py. But we need the
 #   allowed_origins before we load the app
 env_values = dotenv_values(".env")
-ALLOWED_ORIGINS = [
-    origin.strip() for origin in env_values.get("CORS_ALLOWED_ORIGINS", "").split(",")
-]
-SECRET_KEY = env_values.get("JWT_SECRET_KEY")
+
+def read_setting(key: str, default: str | None = None) -> str | None:
+    value = os.getenv(key)
+    if value is not None and value.strip():
+        return value
+    from_env_file = env_values.get(key)
+    if from_env_file is not None and str(from_env_file).strip():
+        return from_env_file
+    return default
+
+ALLOWED_ORIGINS = [origin.strip() for origin in read_setting("CORS_ALLOWED_ORIGINS", "").split(",") if origin.strip()]
+SECRET_KEY = read_setting("JWT_SECRET_KEY")
 
 
 @asynccontextmanager


### PR DESCRIPTION
## Description

Allow JWT Secret and CORS_ALLOWED_ORIGINS to be passed via environment variables. 

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit / integration tests that prove my fix is effective or that my feature works
- [x] I have run all tests locally and they pass
- [x] I have updated the documentation (if applicable)

## How to Test Manually (if necessary)
Already tested in deployment. 