### PR TITLE
AAI-386: Restrict user registration to a restricted list of domains [SBP]

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,8 +17,8 @@ ADMIN_ROLES='["Admin", "GalaxyAdmin"]'
 SEND_EMAIL=False
 # AAI Portal URL for admin links in emails
 AAI_PORTAL_URL=https://aaiportal.example.com
-# Allowed email domains for SBP registration
-SBP_ALLOWED_EMAIL_DOMAINS='["unsw.edu.au", "biocommons.org.au", "sydney.edu.au", "wehi.edu.au", "monash.edu", "griffith.edu.au", "unimelb.edu.au"]'
+# Allowed email domains for SBP registration (note the JSON list syntax)
+SBP_ALLOWED_EMAIL_DOMAINS='["gmail.com", "outlook.com", "example.com", "yahoo.com"]'
 # URL of Galaxy instance, for making calls to Galaxy API
 GALAXY_URL=https://galaxy.example.com
 GALAXY_API_KEY=api-key

--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,8 @@ ADMIN_ROLES='["Admin", "GalaxyAdmin"]'
 SEND_EMAIL=False
 # AAI Portal URL for admin links in emails
 AAI_PORTAL_URL=https://aaiportal.example.com
+# Allowed email domains for SBP registration
+SBP_ALLOWED_EMAIL_DOMAINS='["unsw.edu.au", "biocommons.org.au", "sydney.edu.au", "wehi.edu.au", "monash.edu", "griffith.edu.au", "unimelb.edu.au"]'
 # URL of Galaxy instance, for making calls to Galaxy API
 GALAXY_URL=https://galaxy.example.com
 GALAXY_API_KEY=api-key

--- a/config.py
+++ b/config.py
@@ -21,6 +21,23 @@ class Settings(BaseSettings):
     cors_allowed_origins: str
     # AAI Portal URL for admin links in emails
     aai_portal_url: str = "https://aaiportal.test.biocommons.org.au"
+    # Allowed email domains for SBP registration
+    sbp_allowed_email_domains: list[str] = [
+        # UNSW
+        "@unsw.edu.au", "@ad.unsw.edu.au", "@student.unsw.edu.au",
+        # BioCommons
+        "@biocommons.org.au",
+        # USyd
+        "@sydney.edu.au", "@uni.sydney.edu.au",
+        # WEHI
+        "@wehi.edu.au",
+        # Monash
+        "@monash.edu", "@student.monash.edu",
+        # Griffith
+        "@griffith.edu.au", "@griffithuni.edu.au",
+        # UoM
+        "@unimelb.edu.au", "@student.unimelb.edu.au"
+    ]
 
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 

--- a/config.py
+++ b/config.py
@@ -24,19 +24,19 @@ class Settings(BaseSettings):
     # Allowed email domains for SBP registration
     sbp_allowed_email_domains: list[str] = [
         # UNSW
-        "@unsw.edu.au", "@ad.unsw.edu.au", "@student.unsw.edu.au",
+        "unsw.edu.au", "ad.unsw.edu.au", "student.unsw.edu.au",
         # BioCommons
-        "@biocommons.org.au",
+        "biocommons.org.au",
         # USyd
-        "@sydney.edu.au", "@uni.sydney.edu.au",
+        "sydney.edu.au", "uni.sydney.edu.au",
         # WEHI
-        "@wehi.edu.au",
+        "wehi.edu.au",
         # Monash
-        "@monash.edu", "@student.monash.edu",
+        "monash.edu", "student.monash.edu",
         # Griffith
-        "@griffith.edu.au", "@griffithuni.edu.au",
+        "griffith.edu.au", "griffithuni.edu.au",
         # UoM
-        "@unimelb.edu.au", "@student.unimelb.edu.au"
+        "unimelb.edu.au", "student.unimelb.edu.au"
     ]
 
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")

--- a/routers/sbp_register.py
+++ b/routers/sbp_register.py
@@ -24,28 +24,15 @@ router = APIRouter(
     route_class=RegistrationRoute
 )
 
-# Allowed email domains for SBP registration
-SBP_ALLOWED_EMAIL_DOMAINS = {
-    # UNSW
-    "@unsw.edu.au", "@ad.unsw.edu.au", "@student.unsw.edu.au",
-    # BioCommons
-    "@biocommons.org.au",
-    # USyd
-    "@sydney.edu.au", "@uni.sydney.edu.au",
-    # WEHI
-    "@wehi.edu.au",
-    # Monash
-    "@monash.edu", "@student.monash.edu",
-    # Griffith
-    "@griffith.edu.au", "@griffithuni.edu.au",
-    # UoM
-    "@unimelb.edu.au", "@student.unimelb.edu.au"
-}
+def _validate_email_domain_with_list(email: str, allowed_domains: list[str]) -> bool:
+    email_lower = email.lower()
+    return any(email_lower.endswith(domain) for domain in allowed_domains)
 
 
 def validate_sbp_email_domain(email: str) -> bool:
-    email_lower = email.lower()
-    return any(email_lower.endswith(domain) for domain in SBP_ALLOWED_EMAIL_DOMAINS)
+    from config import get_settings
+    settings = get_settings()
+    return _validate_email_domain_with_list(email, settings.sbp_allowed_email_domains)
 
 
 def send_approval_email(registration: SBPRegistrationRequest, settings: Settings):

--- a/tests/test_sbp_register.py
+++ b/tests/test_sbp_register.py
@@ -9,6 +9,7 @@ from db.models import (
     PlatformMembership,
     PlatformMembershipHistory,
 )
+from routers.sbp_register import validate_sbp_email_domain
 from schemas.biocommons import BiocommonsRegisterData
 from tests.datagen import (
     Auth0UserDataFactory,
@@ -23,7 +24,7 @@ def valid_registration_data():
         username="testuser",
         first_name="Test",
         last_name="User",
-        email="test@example.com",
+        email="test@unsw.edu.au",
         reason="Need access to SBP resources",
         password="SecurePass123!",
     ).model_dump()
@@ -35,6 +36,19 @@ def test_to_biocommons_register_data():
     assert register_data.username == sbp_data.username
     assert register_data.name == f"{sbp_data.first_name} {sbp_data.last_name}"
     assert register_data.app_metadata.registration_from == "sbp"
+
+
+def test_validate_sbp_email_domain_function():
+    # Test approved domains
+    assert validate_sbp_email_domain("user@unsw.edu.au")
+    assert validate_sbp_email_domain("user@biocommons.org.au")
+    assert validate_sbp_email_domain("user@sydney.edu.au")
+    assert validate_sbp_email_domain("USER@UNSW.EDU.AU")
+
+    # Test rejected domains
+    assert not validate_sbp_email_domain("user@gmail.com")
+    assert not validate_sbp_email_domain("user@unsw.com")
+    assert not validate_sbp_email_domain("user@biocommons.org")
 
 
 def test_successful_registration(
@@ -136,3 +150,15 @@ def test_registration_email_format(test_client, valid_registration_data):
     details = response.json()
     errors = details["field_errors"]
     assert "email" in [error["field"] for error in errors]
+
+
+
+def test_registration_rejected_email_domains(test_client, valid_registration_data, mock_auth0_client):
+    data = valid_registration_data.copy()
+    data["email"] = "user@gmail.com"
+
+    response = test_client.post("/sbp/register", json=data)
+
+    assert response.status_code == 400
+    assert "Email domain not approved for SBP registration" in response.json()["message"]
+    assert not mock_auth0_client.create_user.called

--- a/tests/test_sbp_register.py
+++ b/tests/test_sbp_register.py
@@ -39,16 +39,22 @@ def test_to_biocommons_register_data():
 
 
 def test_validate_sbp_email_domain_function():
+    from config import get_settings
+    settings = get_settings()
+
     # Test approved domains
-    assert validate_sbp_email_domain("user@unsw.edu.au")
-    assert validate_sbp_email_domain("user@biocommons.org.au")
-    assert validate_sbp_email_domain("user@sydney.edu.au")
-    assert validate_sbp_email_domain("USER@UNSW.EDU.AU")
+    assert validate_sbp_email_domain("user@unsw.edu.au", settings)
+    assert validate_sbp_email_domain("user@biocommons.org.au", settings)
+    assert validate_sbp_email_domain("user@sydney.edu.au", settings)
+    assert validate_sbp_email_domain("USER@UNSW.EDU.AU", settings)
 
     # Test rejected domains
-    assert not validate_sbp_email_domain("user@gmail.com")
-    assert not validate_sbp_email_domain("user@unsw.com")
-    assert not validate_sbp_email_domain("user@biocommons.org")
+    assert not validate_sbp_email_domain("user@gmail.com", settings)
+    assert not validate_sbp_email_domain("user@unsw.com", settings)
+    assert not validate_sbp_email_domain("user@biocommons.org", settings)
+    assert not validate_sbp_email_domain("user@evilunsw.edu.au", settings)
+    assert not validate_sbp_email_domain("user@malicious.biocommons.org.au", settings)
+    assert not validate_sbp_email_domain("user@fakeunimelb.edu.au", settings)
 
 
 def test_successful_registration(

--- a/tests/test_sbp_register.py
+++ b/tests/test_sbp_register.py
@@ -39,22 +39,31 @@ def test_to_biocommons_register_data():
 
 
 def test_validate_sbp_email_domain_function():
-    from config import get_settings
-    settings = get_settings()
+    from unittest.mock import Mock
+    mock_settings = Mock()
+    mock_settings.sbp_allowed_email_domains = [
+        "unsw.edu.au", "ad.unsw.edu.au", "student.unsw.edu.au",
+        "biocommons.org.au",
+        "sydney.edu.au", "uni.sydney.edu.au",
+        "wehi.edu.au",
+        "monash.edu", "student.monash.edu",
+        "griffith.edu.au", "griffithuni.edu.au",
+        "unimelb.edu.au", "student.unimelb.edu.au"
+    ]
 
     # Test approved domains
-    assert validate_sbp_email_domain("user@unsw.edu.au", settings)
-    assert validate_sbp_email_domain("user@biocommons.org.au", settings)
-    assert validate_sbp_email_domain("user@sydney.edu.au", settings)
-    assert validate_sbp_email_domain("USER@UNSW.EDU.AU", settings)
+    assert validate_sbp_email_domain("user@unsw.edu.au", mock_settings)
+    assert validate_sbp_email_domain("user@biocommons.org.au", mock_settings)
+    assert validate_sbp_email_domain("user@sydney.edu.au", mock_settings)
+    assert validate_sbp_email_domain("USER@UNSW.EDU.AU", mock_settings)
 
     # Test rejected domains
-    assert not validate_sbp_email_domain("user@gmail.com", settings)
-    assert not validate_sbp_email_domain("user@unsw.com", settings)
-    assert not validate_sbp_email_domain("user@biocommons.org", settings)
-    assert not validate_sbp_email_domain("user@evilunsw.edu.au", settings)
-    assert not validate_sbp_email_domain("user@malicious.biocommons.org.au", settings)
-    assert not validate_sbp_email_domain("user@fakeunimelb.edu.au", settings)
+    assert not validate_sbp_email_domain("user@gmail.com", mock_settings)
+    assert not validate_sbp_email_domain("user@unsw.com", mock_settings)
+    assert not validate_sbp_email_domain("user@biocommons.org", mock_settings)
+    assert not validate_sbp_email_domain("user@evilunsw.edu.au", mock_settings)
+    assert not validate_sbp_email_domain("user@malicious.biocommons.org.au", mock_settings)
+    assert not validate_sbp_email_domain("user@fakeunimelb.edu.au", mock_settings)
 
 
 def test_successful_registration(

--- a/tests/test_sbp_register.py
+++ b/tests/test_sbp_register.py
@@ -152,7 +152,6 @@ def test_registration_email_format(test_client, valid_registration_data):
     assert "email" in [error["field"] for error in errors]
 
 
-
 def test_registration_rejected_email_domains(test_client, valid_registration_data, mock_auth0_client):
     data = valid_registration_data.copy()
     data["email"] = "user@gmail.com"


### PR DESCRIPTION
## Description

[AAI-386](https://biocloud.atlassian.net/jira/software/c/projects/BPB/boards/22?assignee=63f30233526117e1514b222b&selectedIssue=AAI-386): Restrict user registration to a restricted list of domains [SBP]

## Changes

- Added email domain validation for sbp register route
- Added sbp allowed list to settings
- Added/updated relevant tests

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit / integration tests that prove my fix is effective or that my feature works
- [x] I have run all tests locally and they pass
- [x] I have updated the documentation (if applicable)


[AAI-386]: https://biocloud.atlassian.net/browse/AAI-386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ