### PR TITLE
chore: add copilot instructions to ensure Conventional Commit messages

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,10 @@
+## Commit Messages
+
+Commit messages should follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines,
+i.e.:
+
+* fix: a commit of the type fix patches a bug in your codebase (this correlates with PATCH in Semantic Versioning).
+* feat: a commit of the type feat introduces a new feature to the codebase (this correlates with MINOR in Semantic Versioning).
+* BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.
+* types other than fix: and feat: are allowed, for example @commitlint/config-conventional (based on the Angular convention) recommends build:, chore:, ci:, docs:, style:, refactor:, perf:, test:, and others.
+* footers other than BREAKING CHANGE: <description> may be provided and follow a convention similar to git trailer format.


### PR DESCRIPTION
## Description

Add `copilot-instructions.md` to customize how Copilot does reviews/provides suggestions. For now, just specify Conventional Commits - can do further customizations later if needed.