### PR TITLE
docs: add reminder to update secrets

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,7 @@
 - [ ] I have added unit / integration tests that prove my fix is effective or that my feature works
 - [ ] I have run all tests locally and they pass
 - [ ] I have updated the documentation (if applicable)
-- [ ] For any new secrets, I have updated the [shared spreadsheet](https://docs.google.com/spreadsheets/d/16lGloFh4VxMmu6cJdeFVLy2654hdq-ZeErhB8UifSfI/edit?usp=sharing) and the [GitHub Secrets](https://github.com/AustralianBioCommons/aai-portal/settings/secrets/actions).
+- [ ] For any new secrets, I have updated the [shared spreadsheet](https://docs.google.com/spreadsheets/d/16lGloFh4VxMmu6cJdeFVLy2654hdq-ZeErhB8UifSfI/edit?usp=sharing) and the [GitHub Secrets](https://github.com/AustralianBioCommons/aai-backend/settings/secrets/actions).
 
 ## How to Test Manually (if necessary)
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,6 +14,7 @@
 - [ ] I have added unit / integration tests that prove my fix is effective or that my feature works
 - [ ] I have run all tests locally and they pass
 - [ ] I have updated the documentation (if applicable)
+- [ ] For any new secrets, I have updated the [shared spreadsheet](https://docs.google.com/spreadsheets/d/16lGloFh4VxMmu6cJdeFVLy2654hdq-ZeErhB8UifSfI/edit?usp=sharing) and the [GitHub Secrets](https://github.com/AustralianBioCommons/aai-portal/settings/secrets/actions).
 
 ## How to Test Manually (if necessary)
 


### PR DESCRIPTION
This pull request documents and remind us to manage secrets.

## Changes

- Updated pull request template to remind us to update secrets


## Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit / integration tests that prove my fix is effective or that my feature works
- [ ] I have run all tests locally and they pass
- [x] I have updated the documentation (if applicable)
