### PR TITLE
feat: group and role sync to initialize/populate the backend database (AAI-452)

### DIFF
--- a/auth0/client.py
+++ b/auth0/client.py
@@ -198,6 +198,21 @@ class Auth0Client:
         else:
             return self._convert_roles(resp)
 
+    def get_all_roles(self) -> list[RoleData]:
+        """
+        Iterate through pages to get all roles.
+        """
+        page = 0
+        per_page = 100
+        roles = []
+        while True:
+            page_roles: RolesWithTotals = self.get_roles(page=page, per_page=per_page, include_totals=True)
+            roles.extend(page_roles.roles)
+            if len(roles) >= page_roles.total:
+                break
+            page += 1
+        return roles
+
     def get_role_by_name(self, name: str) -> RoleData:
         """
         Get a role by name.

--- a/db/types.py
+++ b/db/types.py
@@ -42,7 +42,14 @@ class GroupMembershipData(BaseModel):
     revocation_reason: str | None = None
 
 
-# Not used for Groups in the database yet
 class GroupEnum(str, Enum):
     TSI = "biocommons/group/tsi"
     BPA_GALAXY = "biocommons/group/bpa_galaxy"
+
+
+# Provide default group names so we can populate the DB easily
+#   - should use the DB values when looking them up though
+GROUP_NAMES: dict[GroupEnum, str] = {
+    GroupEnum.TSI: "Threatened Species Initiative",
+    GroupEnum.BPA_GALAXY: "Bioplatforms Australia Data Portal & Galaxy Australia",
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "apscheduler[redis,sqlalchemy]~=3.11",
     "loguru>=0.7.3",
     "cachetools~=6.2",
+    "typer>=0.16.0",
 ]
 
 [project.optional-dependencies]

--- a/run_scheduler.py
+++ b/run_scheduler.py
@@ -3,11 +3,14 @@ import signal
 import sys
 from datetime import UTC, datetime, timedelta
 
+import typer
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.date import DateTrigger
 from apscheduler.triggers.interval import IntervalTrigger
 from loguru import logger
+from sqlalchemy import text
 
+from db.setup import get_engine
 from scheduled_tasks.scheduler import SCHEDULER
 from scheduled_tasks.tasks import populate_db_groups, sync_auth0_roles, sync_auth0_users
 
@@ -17,7 +20,9 @@ def schedule_jobs(scheduler: AsyncIOScheduler):
     logger.info("Adding one-off job: populate DB groups")
     scheduler.add_job(
         populate_db_groups,
-        trigger=DateTrigger(run_date=datetime.now(UTC))
+        trigger=DateTrigger(run_date=datetime.now(UTC)),
+        id="populate_db_groups",
+        replace_existing=True
     )
     logger.info("Adding hourly job: sync_auth0_roles")
     scheduler.add_job(
@@ -37,7 +42,43 @@ def schedule_jobs(scheduler: AsyncIOScheduler):
     )
 
 
-async def main():
+def clear_db_jobs():
+    engine = get_engine()
+    with engine.connect() as conn:
+        conn.execute(text("DELETE FROM apscheduler_jobs"))
+        conn.commit()
+    engine.dispose()
+    logger.info("Database jobs cleared")
+
+
+async def run_immediate():
+    logger.info("Clearing existing jobs")
+    clear_db_jobs()
+    now_trigger = DateTrigger(run_date=datetime.now(UTC))
+    logger.info("Adding one-off job: populate DB groups")
+    SCHEDULER.add_job(
+        populate_db_groups,
+        trigger=now_trigger,
+        id="populate_db_groups",
+        replace_existing=True
+    )
+    logger.info("Adding one-off job: sync_auth0_roles")
+    SCHEDULER.add_job(
+        sync_auth0_roles,
+        trigger=now_trigger,
+        id="sync_auth0_roles",
+        replace_existing=True
+    )
+    SCHEDULER.start()
+    logger.info("Scheduler started, waiting for jobs to complete...")
+    while SCHEDULER.get_jobs():
+        SCHEDULER.print_jobs()
+        await asyncio.sleep(0.5)
+    logger.info("Stopping scheduler")
+    SCHEDULER.shutdown(wait=True)
+
+
+async def run_with_scheduler():
     logger.info("Setting up scheduler")
     schedule_jobs(SCHEDULER)
     logger.info("Starting scheduler")
@@ -53,6 +94,14 @@ async def main():
     SCHEDULER.shutdown(wait=False)
 
 
+def main(immediate: bool = False):
+    if immediate:
+        asyncio.run(run_immediate())
+    else:
+        asyncio.run(run_with_scheduler())
+
+
+
 if __name__ == "__main__":
     logger.remove()
     logger.add(
@@ -60,4 +109,4 @@ if __name__ == "__main__":
         format="<green>{time:YYYY-MM-DD HH:mm:ss}</green>\t<level>{level}</level>\t{message}\t<blue>{name}</blue>\t<cyan>{extra}</cyan>",
         level="INFO"
     )
-    asyncio.run(main())
+    typer.run(main)

--- a/run_scheduler.py
+++ b/run_scheduler.py
@@ -69,6 +69,13 @@ async def run_immediate():
         id="sync_auth0_roles",
         replace_existing=True
     )
+    logger.info("Adding one-off job: sync_auth0_users")
+    SCHEDULER.add_job(
+        sync_auth0_users,
+        trigger=now_trigger,
+        id="sync_auth0_users",
+        replace_existing=True
+    )
     SCHEDULER.start()
     logger.info("Scheduler started, waiting for jobs to complete...")
     while SCHEDULER.get_jobs():
@@ -99,7 +106,6 @@ def main(immediate: bool = False):
         asyncio.run(run_immediate())
     else:
         asyncio.run(run_with_scheduler())
-
 
 
 if __name__ == "__main__":

--- a/scheduled_tasks/tasks.py
+++ b/scheduled_tasks/tasks.py
@@ -3,13 +3,15 @@ from loguru import logger
 from auth.management import get_management_token
 from auth0.client import Auth0Client
 from config import get_settings
-from db.models import BiocommonsUser
+from db.models import Auth0Role, BiocommonsGroup, BiocommonsUser
 from db.setup import get_db_session
+from db.types import GROUP_NAMES, GroupEnum
 from scheduled_tasks.scheduler import SCHEDULER
 from schemas.biocommons import Auth0UserData
 
 
 async def sync_auth0_users():
+    logger.info("Syncing Auth0 users")
     logger.info("Setting up Auth0 client")
     settings = get_settings()
     token = get_management_token(settings=settings)
@@ -43,3 +45,48 @@ async def update_auth0_user(user_data: Auth0UserData):
     # Should be OK to commit as SQLAlchemy will only update modified fields
     session.commit()
     return True
+
+
+async def sync_auth0_roles():
+    logger.info("Syncing Auth0 roles")
+    logger.info("Setting up Auth0 client")
+    settings = get_settings()
+    token = get_management_token(settings=settings)
+    auth0_client = Auth0Client(domain=settings.auth0_domain, management_token=token)
+    roles = auth0_client.get_all_roles()
+    logger.info(f"Found {len(roles)} roles")
+
+    db_session = next(get_db_session())
+    with db_session.begin():
+        for role in roles:
+            logger.info(f"  Role: {role.name}")
+            db_role = db_session.get(Auth0Role, role.id)
+            if db_role is not None:
+                logger.info("    Role already exists in DB")
+                continue
+            else:
+                logger.info("    Role does not exist in DB, creating")
+                db_role = Auth0Role(
+                    id=role.id,
+                    name=role.name,
+                    description=role.description
+                )
+                db_session.add(db_role)
+
+
+async def populate_db_groups():
+    logger.info("Populating DB groups")
+    db_session = next(get_db_session())
+    with db_session.begin():
+        for group in GroupEnum:
+            logger.info(f"  Group: {group.value}")
+            db_group = db_session.get(BiocommonsGroup, group.value)
+            if db_group is not None:
+                logger.info("    Group already exists in DB")
+                continue
+            else:
+                logger.info("    Group does not exist in DB, creating")
+                name = GROUP_NAMES.get(group, group.value)
+                db_group = BiocommonsGroup(group_id=group.value, name=name)
+                db_session.add(db_group)
+        db_session.commit()

--- a/uv.lock
+++ b/uv.lock
@@ -15,13 +15,14 @@ dependencies = [
     { name = "fastapi", extra = ["standard"] },
     { name = "httpx" },
     { name = "itsdangerous" },
-    { name = "prometheus-fastapi-instrumentator" },
     { name = "loguru" },
+    { name = "prometheus-fastapi-instrumentator" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pydantic-settings" },
     { name = "python-jose" },
     { name = "sqladmin" },
     { name = "sqlmodel" },
+    { name = "typer" },
 ]
 
 [package.optional-dependencies]
@@ -67,6 +68,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4.4" },
     { name = "sqladmin", specifier = ">=0.21.0" },
     { name = "sqlmodel", specifier = ">=0.0.24" },
+    { name = "typer", specifier = ">=0.16.0" },
 ]
 provides-extras = ["dev"]
 


### PR DESCRIPTION
## Description

[AAI-452](https://biocloud.atlassian.net/browse/AAI-452): need to sync roles from Auth0, and populate groups in the database, so that the backend database is initialized and ready for user registration etc.

## Changes

- Task to sync roles from Auth0 - scheduled hourly to keep things in sync
- Task to populate groups in the DB - run as a one-off job
- Tasks added to scheduler

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit / integration tests that prove my fix is effective or that my feature works
- [ ] I have run all tests locally and they pass
- [ ] I have updated the documentation (if applicable)
- [ ] For any new secrets, I have updated the [shared spreadsheet](https://docs.google.com/spreadsheets/d/16lGloFh4VxMmu6cJdeFVLy2654hdq-ZeErhB8UifSfI/edit?usp=sharing) and the [GitHub Secrets](https://github.com/AustralianBioCommons/aai-backend/settings/secrets/actions).

## How to Test Manually (if necessary)

Run `uv run python run_scheduler.py` - group and role sync should be run immediately, and the role sync added as a job that will repeat hourly.


[AAI-452]: https://biocloud.atlassian.net/browse/AAI-452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ