### PR TITLE
feat: added endpoint for checking admin groups (AAI-378)

### DIFF
--- a/routers/user.py
+++ b/routers/user.py
@@ -55,6 +55,14 @@ class CombinedMembershipData(PydanticBaseModel):
     groups: list[GroupMembershipData]
 
 
+class PlatformAdminData(PydanticBaseModel):
+    """
+    Data model for platform admin response.
+    """
+    id: str
+    name: str
+
+
 class GroupAdminData(PydanticBaseModel):
     """
     Data model for group admin response.
@@ -165,6 +173,7 @@ async def get_pending_platforms(
 
 @router.get(
     "/platforms/admin-roles",
+    response_model=list[PlatformAdminData],
     description="Get platforms for which the current user has admin privileges.",
 )
 async def get_admin_platforms(

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -427,7 +427,12 @@ def test_get_admin_platforms(test_client, test_db_session, mocker, persistent_fa
     response = test_client.get("/me/platforms/admin-roles", headers={"Authorization": "Bearer valid_token"})
     assert response.status_code == 200
     data = response.json()
-    assert data[0] == valid_platform.model_dump(mode="json")
+    assert len(data) == 1
+    assert data[0]["id"] == valid_platform.id
+    assert data[0]["name"] == valid_platform.name
+    # Should not include relationships or other fields
+    assert "admin_roles" not in data[0]
+    assert "platform_role" not in data[0]
     returned_ids = [p["id"] for p in data]
     assert invalid_platform.id not in returned_ids
 


### PR DESCRIPTION
## Description

[AAI-378](https://biocloud.atlassian.net/jira/software/c/projects/AAI/boards/53?assignee=63f30233526117e1514b222b&selectedIssue=AAI-378): Added endpoint for checking admin groups (bundle)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit / integration tests that prove my fix is effective or that my feature works
- [x] I have run all tests locally and they pass
- [ ] I have updated the documentation (if applicable)
- [ ] For any new secrets, I have updated the [shared spreadsheet](https://docs.google.com/spreadsheets/d/16lGloFh4VxMmu6cJdeFVLy2654hdq-ZeErhB8UifSfI/edit?usp=sharing) and the [GitHub Secrets](https://github.com/AustralianBioCommons/aai-backend/settings/secrets/actions).


[AAI-378]: https://biocloud.atlassian.net/browse/AAI-378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ