### PR TITLE
feat: add TSI bundle rejection email

### DIFF
--- a/biocommons/emails.py
+++ b/biocommons/emails.py
@@ -333,6 +333,51 @@ def compose_welcome_email(
     return subject, _wrap_email_html(subject, subject, body_content, portal_url)
 
 
+def compose_group_membership_rejected_email(
+    *,
+    group_name: str,
+    group_short_name: str,
+    first_name: str,
+    settings: Settings,
+) -> tuple[str, str]:
+    """
+    Notify a user that their group/bundle access request was rejected.
+    For the TSI bundle, includes detailed information about open-access alternatives.
+    """
+    portal_url = settings.aai_portal_url or ""
+    safe_group_name = html.escape(group_name or "")
+    safe_first_name = html.escape(first_name or "")
+    subject = f"Your {group_name} Service Bundle request"
+
+    is_tsi = (group_short_name or "").upper() == "TSI"
+    if is_tsi:
+        extra_content = f"""
+        <p style="{_P}">The TSI Bundle available on the Australian BioCommons Access is only for members of the Threatened Species Initiative consortium.</p>
+        <p style="{_P}">Members are collaborators who have projects supported through our request for partnership rounds. They can access datasets that are under embargo for the first 12 months following their generation.</p>
+        <p style="{_P}">The Threatened Species Initiative is generating genomic resources that are made openly accessible to the community with the standard registration to the Bioplatforms Australia data portal (now Australian BioCommons Access). You do not need to apply to the TSI Bundle to obtain access to these open access genomics datasets. This is also the case for datasets of all other initiatives presented on the Bioplatforms Data Portal.</p>
+        <p style="{_P}">Similarly the access to various tools, including <a href="https://www.biocommons.org.au/fgenesh-plus-plus" target="_blank" rel="noopener noreferrer" style="{_A}">Fgenesh++</a>, can be obtained through Galaxy Australia without the need of the TSI Bundle:</p>
+        <ul style="margin: 0 0 12px; padding-left: 24px; text-align: left;">
+          <li style="font-size: 16px; line-height: 24px; color: #171717;"><a href="https://site.usegalaxy.org.au/" target="_blank" rel="noopener noreferrer" style="{_A}">Galaxy Australia</a></li>
+        </ul>
+        <p style="{_P}">Please do not hesitate to reach out to us for any non registration related issues:</p>
+        <ul style="margin: 0 0 12px; padding-left: 24px; text-align: left;">
+          <li style="font-size: 16px; line-height: 24px; color: #171717;">Bioplatforms Australia Data Portal — <a href="mailto:help@bioplatforms.com" style="{_A}">help@bioplatforms.com</a></li>
+          <li style="font-size: 16px; line-height: 24px; color: #171717;"><a href="https://site.usegalaxy.org.au/" target="_blank" rel="noopener noreferrer" style="{_A}">Galaxy Australia</a></li>
+          <li style="font-size: 16px; line-height: 24px; color: #171717;">TSI specific enquiries — <a href="mailto:smazard@bioplatforms.com" style="{_A}">smazard@bioplatforms.com</a></li>
+        </ul>"""
+    else:
+        extra_content = ""
+
+    body_content = f"""
+        <p style="{_P}">Dear {safe_first_name},</p>
+        <p style="{_P}">Thank you for your interest in the {safe_group_name} Bundle.</p>
+        {extra_content}
+        <p style="{_P_SIGN_OFF}">Thank you,</p>
+        <p style="{_P}">BioCommons Access team</p>
+    """
+    return subject, _wrap_email_html(subject, subject, body_content, portal_url)
+
+
 def compose_bundle_request_confirmation_email(
     *,
     first_name: str,

--- a/biocommons/emails.py
+++ b/biocommons/emails.py
@@ -336,7 +336,6 @@ def compose_welcome_email(
 def compose_group_membership_rejected_email(
     *,
     group_name: str,
-    group_short_name: str,
     first_name: str,
     settings: Settings,
 ) -> tuple[str, str]:
@@ -349,9 +348,9 @@ def compose_group_membership_rejected_email(
     safe_first_name = html.escape(first_name or "")
     subject = f"Your {group_name} Service Bundle request"
 
-    is_tsi = (group_short_name or "").upper() == "TSI"
-    if is_tsi:
-        extra_content = f"""
+    body_content = f"""
+        <p style="{_P}">Dear {safe_first_name},</p>
+        <p style="{_P}">Thank you for your interest in the {safe_group_name} Bundle.</p>
         <p style="{_P}">The TSI Bundle available on the Australian BioCommons Access is only for members of the Threatened Species Initiative consortium.</p>
         <p style="{_P}">Members are collaborators who have projects supported through our request for partnership rounds. They can access datasets that are under embargo for the first 12 months following their generation.</p>
         <p style="{_P}">The Threatened Species Initiative is generating genomic resources that are made openly accessible to the community with the standard registration to the Bioplatforms Australia data portal (now Australian BioCommons Access). You do not need to apply to the TSI Bundle to obtain access to these open access genomics datasets. This is also the case for datasets of all other initiatives presented on the Bioplatforms Data Portal.</p>
@@ -364,14 +363,7 @@ def compose_group_membership_rejected_email(
           <li style="font-size: 16px; line-height: 24px; color: #171717;">Bioplatforms Australia Data Portal — <a href="mailto:help@bioplatforms.com" style="{_A}">help@bioplatforms.com</a></li>
           <li style="font-size: 16px; line-height: 24px; color: #171717;"><a href="https://site.usegalaxy.org.au/" target="_blank" rel="noopener noreferrer" style="{_A}">Galaxy Australia</a></li>
           <li style="font-size: 16px; line-height: 24px; color: #171717;">TSI specific enquiries — <a href="mailto:smazard@bioplatforms.com" style="{_A}">smazard@bioplatforms.com</a></li>
-        </ul>"""
-    else:
-        extra_content = ""
-
-    body_content = f"""
-        <p style="{_P}">Dear {safe_first_name},</p>
-        <p style="{_P}">Thank you for your interest in the {safe_group_name} Bundle.</p>
-        {extra_content}
+        </ul>
         <p style="{_P_SIGN_OFF}">Thank you,</p>
         <p style="{_P}">BioCommons Access team</p>
     """

--- a/routers/admin.py
+++ b/routers/admin.py
@@ -30,6 +30,7 @@ from auth0.client import Auth0Client, UpdateUserData, get_auth0_client
 from biocommons.emails import (
     compose_email_change_notification,
     compose_group_membership_approved_email,
+    compose_group_membership_rejected_email,
     compose_username_change_notification,
     format_first_name,
 )
@@ -1246,8 +1247,11 @@ def approve_group_membership(user_id: Annotated[str, UserIdParam],
 def reject_group_membership(user_id: Annotated[str, UserIdParam],
                             group_id: Annotated[str, ServiceIdParam],
                             payload: RejectServiceRequest,
+                            client: Annotated[Auth0Client, Depends(get_auth0_client)],
                             admin_record: Annotated[BiocommonsUser, Depends(get_db_user)],
-                            db_session: Annotated[Session, Depends(get_db_session)]):
+                            db_session: Annotated[Session, Depends(get_db_session)],
+                            settings: Annotated[Settings, Depends(get_settings)]):
+    group_record = BiocommonsGroup.get_by_id_or_404(group_id, db_session)
     membership = GroupMembership.get_by_user_id_and_group_id_or_404(
         user_id=user_id,
         group_id=group_id,
@@ -1264,6 +1268,30 @@ def reject_group_membership(user_id: Annotated[str, UserIdParam],
         session=db_session,
         commit=False,
     )
+    if membership.user and membership.user.email:
+        first_name = "there"
+        try:
+            auth0_user = client.get_user(membership.user.id)
+            first_name = format_first_name(
+                full_name=auth0_user.name,
+                given_name=auth0_user.given_name,
+                fallback="there",
+            )
+        except Exception:
+            pass
+        subject, body_html = compose_group_membership_rejected_email(
+            group_name=group_record.name,
+            group_short_name=group_record.short_name,
+            first_name=first_name,
+            settings=settings,
+        )
+        enqueue_email(
+            session=db_session,
+            to_address=membership.user.email,
+            subject=subject,
+            body_html=body_html,
+            settings=settings,
+        )
     db_session.commit()
     logger.info(
         "Rejected group %s for user %s: %s",

--- a/routers/admin.py
+++ b/routers/admin.py
@@ -1268,7 +1268,7 @@ def reject_group_membership(user_id: Annotated[str, UserIdParam],
         session=db_session,
         commit=False,
     )
-    if membership.user and membership.user.email:
+    if group_id == GroupEnum.TSI.value and membership.user and membership.user.email:
         first_name = "there"
         try:
             auth0_user = client.get_user(membership.user.id)
@@ -1281,7 +1281,6 @@ def reject_group_membership(user_id: Annotated[str, UserIdParam],
             pass
         subject, body_html = compose_group_membership_rejected_email(
             group_name=group_record.name,
-            group_short_name=group_record.short_name,
             first_name=first_name,
             settings=settings,
         )

--- a/tests/admin_api/test_admin.py
+++ b/tests/admin_api/test_admin.py
@@ -1335,6 +1335,7 @@ def test_reject_group_membership_records_reason(
     test_db_session,
     as_admin_user,
     tsi_group,
+    mock_auth0_client,
     persistent_factories,
 ):
     user = BiocommonsUserFactory.create_sync(group_memberships=[])
@@ -1367,6 +1368,35 @@ def test_reject_group_membership_records_reason(
         session=test_db_session,
     )
     assert history[-1].reason == reason
+
+
+def test_reject_group_membership_sends_email(
+    test_client,
+    test_db_session,
+    as_admin_user,
+    tsi_group,
+    mock_auth0_client,
+    persistent_factories,
+):
+    user = BiocommonsUserFactory.create_sync(group_memberships=[])
+    GroupMembershipFactory.create_sync(
+        group=tsi_group,
+        user=user,
+        approval_status=ApprovalStatusEnum.PENDING.value,
+    )
+    test_db_session.commit()
+
+    group_url = quote(tsi_group.group_id, safe='')
+    resp = test_client.post(
+        f"/admin/users/{user.id}/groups/{group_url}/reject",
+        json={"reason": "Not a TSI consortium member"},
+    )
+
+    assert resp.status_code == 200
+    queued_emails = test_db_session.exec(select(EmailNotification)).all()
+    assert len(queued_emails) == 1
+    assert queued_emails[0].to_address == user.email
+    assert queued_emails[0].status == EmailStatusEnum.PENDING
 
 
 def test_reject_group_membership_forbidden_without_group_role(


### PR DESCRIPTION
## Description

[AAI-813](https://biocloud.atlassian.net/browse/AAI-813):  Add TSI bundle rejection email

Also added in email template: https://biocloud.atlassian.net/wiki/spaces/AAAI/pages/534478851/BioCommons+Access+email+templates+content#TSI-Bundle-Rejection-Email-%5BinlineCard%5D

## Changes

- Adds `compose_group_membership_rejected_email()` email template in `biocommons/emails.py` with TSI-specific content explaining consortium membership, open-access alternatives, and contact details
- Updates the `reject_group_membership` endpoint in `routers/admin.py` to enqueue a rejection email to the requester on rejection (mirrors the existing approve flow)
- Updates existing rejection test to include `mock_auth0_client`, and adds a new test asserting the email is queued on rejection

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit / integration tests that prove my fix is effective or that my feature works
- [x] I have run all tests locally and they pass
- [x] I have updated the documentation (if applicable)
- [ ] For any new secrets, I have updated the [shared spreadsheet](https://docs.google.com/spreadsheets/d/16lGloFh4VxMmu6cJdeFVLy2654hdq-ZeErhB8UifSfI/edit?usp=sharing) and the [GitHub Secrets](https://github.com/AustralianBioCommons/aai-backend/settings/secrets/actions).

## How to Test Manually (if necessary)

`uv run pytest`

## UI - Sample TSI bundle rejection email
<img width="1512" height="841" alt="Screenshot 2026-04-17 at 11 15 14 am" src="https://github.com/user-attachments/assets/c0b3dd52-2356-477b-9dc7-9244f2d2cf09" />


[AAI-813]: https://biocloud.atlassian.net/browse/AAI-813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ