### PR TITLE
fix: polish TSI bundle rejection email content

### DIFF
--- a/biocommons/emails.py
+++ b/biocommons/emails.py
@@ -336,7 +336,7 @@ def compose_welcome_email(
 def compose_group_membership_rejected_email(
     *,
     group_name: str,
-    first_name: str,
+    username: str,
     settings: Settings,
 ) -> tuple[str, str]:
     """
@@ -345,27 +345,28 @@ def compose_group_membership_rejected_email(
     """
     portal_url = settings.aai_portal_url or ""
     safe_group_name = html.escape(group_name or "")
-    safe_first_name = html.escape(first_name or "")
-    subject = f"Your {group_name} Service Bundle request"
+    safe_username = html.escape(username or "")
+    subject = "Threatened Species Initiative service bundle request"
 
+    _TSI_LINK = f'<a href="https://bioplatforms.com/project/threatened-species/" target="_blank" rel="noopener noreferrer" style="{_A}">Threatened Species Initiative</a>'
     body_content = f"""
-        <p style="{_P}">Dear {safe_first_name},</p>
+        <p style="{_P}">Dear {safe_username},</p>
         <p style="{_P}">Thank you for your interest in the {safe_group_name} Bundle.</p>
-        <p style="{_P}">The TSI Bundle available on the Australian BioCommons Access is only for members of the Threatened Species Initiative consortium.</p>
+        <p style="{_P}">The TSI Bundle available on BioCommons Access is only for members of the {_TSI_LINK} consortium.</p>
         <p style="{_P}">Members are collaborators who have projects supported through our request for partnership rounds. They can access datasets that are under embargo for the first 12 months following their generation.</p>
-        <p style="{_P}">The Threatened Species Initiative is generating genomic resources that are made openly accessible to the community with the standard registration to the Bioplatforms Australia data portal (now Australian BioCommons Access). You do not need to apply to the TSI Bundle to obtain access to these open access genomics datasets. This is also the case for datasets of all other initiatives presented on the Bioplatforms Data Portal.</p>
-        <p style="{_P}">Similarly the access to various tools, including <a href="https://www.biocommons.org.au/fgenesh-plus-plus" target="_blank" rel="noopener noreferrer" style="{_A}">Fgenesh++</a>, can be obtained through Galaxy Australia without the need of the TSI Bundle:</p>
+        <p style="{_P}">The {_TSI_LINK} is generating genomic resources that are made openly accessible to the community with the standard registration to the Bioplatforms Australia data portal (now Australian BioCommons Access). You do not need to apply to the TSI Bundle to obtain access to these open access genomics datasets. This is also the case for datasets of all other initiatives presented on the <a href="https://data.bioplatforms.com/all_projects" target="_blank" rel="noopener noreferrer" style="{_A}">Bioplatforms Data Portal</a>.</p>
+        <p style="{_P}">Similarly, various tools - including <a href="https://www.biocommons.org.au/fgenesh-plus-plus" target="_blank" rel="noopener noreferrer" style="{_A}">FGenesh++</a> and AlphaFold, can be directly accessed through <a href="https://site.usegalaxy.org.au/" target="_blank" rel="noopener noreferrer" style="{_A}">Galaxy Australia</a> without the need of the TSI Bundle:</p>
         <ul style="margin: 0 0 12px; padding-left: 24px; text-align: left;">
-          <li style="font-size: 16px; line-height: 24px; color: #171717;"><a href="https://site.usegalaxy.org.au/" target="_blank" rel="noopener noreferrer" style="{_A}">Galaxy Australia</a></li>
+          <li style="font-size: 16px; line-height: 24px; color: #171717;"><a href="https://site.usegalaxy.org.au/request/access" target="_blank" rel="noopener noreferrer" style="{_A}">Request access to specialist tools</a></li>
         </ul>
         <p style="{_P}">Please do not hesitate to reach out to us for any non registration related issues:</p>
         <ul style="margin: 0 0 12px; padding-left: 24px; text-align: left;">
           <li style="font-size: 16px; line-height: 24px; color: #171717;">Bioplatforms Australia Data Portal — <a href="mailto:help@bioplatforms.com" style="{_A}">help@bioplatforms.com</a></li>
-          <li style="font-size: 16px; line-height: 24px; color: #171717;"><a href="https://site.usegalaxy.org.au/" target="_blank" rel="noopener noreferrer" style="{_A}">Galaxy Australia</a></li>
+          <li style="font-size: 16px; line-height: 24px; color: #171717;">Galaxy Australia — <a href="https://site.usegalaxy.org.au/request/" target="_blank" rel="noopener noreferrer" style="{_A}">Galaxy Australia - Help and support</a></li>
           <li style="font-size: 16px; line-height: 24px; color: #171717;">TSI specific enquiries — <a href="mailto:smazard@bioplatforms.com" style="{_A}">smazard@bioplatforms.com</a></li>
         </ul>
         <p style="{_P_SIGN_OFF}">Thank you,</p>
-        <p style="{_P}">BioCommons Access team</p>
+        <p style="{_P}">BioCommons Access Team</p>
     """
     return subject, _wrap_email_html(subject, subject, body_content, portal_url)
 

--- a/routers/admin.py
+++ b/routers/admin.py
@@ -1247,7 +1247,6 @@ def approve_group_membership(user_id: Annotated[str, UserIdParam],
 def reject_group_membership(user_id: Annotated[str, UserIdParam],
                             group_id: Annotated[str, ServiceIdParam],
                             payload: RejectServiceRequest,
-                            client: Annotated[Auth0Client, Depends(get_auth0_client)],
                             admin_record: Annotated[BiocommonsUser, Depends(get_db_user)],
                             db_session: Annotated[Session, Depends(get_db_session)],
                             settings: Annotated[Settings, Depends(get_settings)]):
@@ -1269,19 +1268,9 @@ def reject_group_membership(user_id: Annotated[str, UserIdParam],
         commit=False,
     )
     if group_id == GroupEnum.TSI.value and membership.user and membership.user.email:
-        first_name = "there"
-        try:
-            auth0_user = client.get_user(membership.user.id)
-            first_name = format_first_name(
-                full_name=auth0_user.name,
-                given_name=auth0_user.given_name,
-                fallback="there",
-            )
-        except Exception:
-            pass
         subject, body_html = compose_group_membership_rejected_email(
             group_name=group_record.name,
-            first_name=first_name,
+            username=membership.user.username,
             settings=settings,
         )
         enqueue_email(


### PR DESCRIPTION
## Description

[AAI-813](https://biocloud.atlassian.net/browse/AAI-813):  Polish TSI Bundle rejection email as per Sophie's request. The email content is recorded here: https://biocloud.atlassian.net/wiki/spaces/AAAI/pages/534478851/BioCommons+Access+email+templates+content#TSI-Bundle-Rejection-Email-[inlineCard]

## Changes

- Email content updated to match the approved TSI bundle rejection template on Confluence page — corrected subject line, portal name, tools paragraph (added AlphaFold), and contact section link labels
- Email salutation now uses username instead of first name fetched from Auth0, removing an unnecessary external API call

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit / integration tests that prove my fix is effective or that my feature works
- [x] I have run all tests locally and they pass
- [x] I have updated the documentation (if applicable)
- [ ] For any new secrets, I have updated the [shared spreadsheet](https://docs.google.com/spreadsheets/d/16lGloFh4VxMmu6cJdeFVLy2654hdq-ZeErhB8UifSfI/edit?usp=sharing) and the [GitHub Secrets](https://github.com/AustralianBioCommons/aai-backend/settings/secrets/actions).

## How to Test Manually (if necessary)

`uv run pytest`

<img width="1504" height="912" alt="Screenshot 2026-04-30 at 3 00 17 pm" src="https://github.com/user-attachments/assets/9e91bc35-189a-4f64-9919-1297cdd6836f" />


[AAI-813]: https://biocloud.atlassian.net/browse/AAI-813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ