### PR TITLE
feat: enable automatic sbp platform for users

### DIFF
--- a/routers/sbp_register.py
+++ b/routers/sbp_register.py
@@ -8,7 +8,7 @@ from starlette.responses import JSONResponse, Response
 
 from auth0.client import Auth0Client, get_auth0_client
 from config import Settings, get_settings
-from db.models import BiocommonsUser, BiocommonsUserHistory, Platform, PlatformEnum
+from db.models import BiocommonsUser, BiocommonsUserHistory, PlatformEnum
 from db.setup import get_db_session
 from routers.errors import RegistrationRoute
 from routers.utils import check_existing_user
@@ -19,7 +19,6 @@ from schemas.responses import (
     RegistrationResponse,
 )
 from schemas.sbp import SBPRegistrationRequest
-from services.email_queue import enqueue_email
 
 logger = logging.getLogger("uvicorn.error")
 
@@ -38,49 +37,6 @@ def validate_sbp_email_domain(email: str, settings: Settings) -> bool:
         return domain in allowed_domains_lower
     except EmailNotValidError:
         return False
-
-
-def compose_sbp_registration_email(registration: SBPRegistrationRequest, settings: Settings) -> tuple[str, str]:
-    """Compose the approval email for SBP admins."""
-    subject = "New Structural Biology Platform User Registration"
-
-    body_html = f"""
-        <p>A new user has registered for the Structural Biology Platform.</p>
-        <p><strong>User:</strong> {registration.first_name} {registration.last_name} ({registration.email})</p>
-        <p><strong>Username:</strong> {registration.username}</p>
-        <p><strong>Registration Reason:</strong> {registration.request_reason}</p>
-        <p>Please <a href='{settings.aai_portal_url}'>log into the AAI Admin Portal</a> to review and approve access.</p>
-    """
-
-    return subject, body_html
-
-
-def queue_sbp_admin_notifications(
-    registration: SBPRegistrationRequest,
-    db_session: Session,
-    auth0_client: Auth0Client,
-    settings: Settings,
-) -> None:
-    """Queue approval emails for SBP platform admins."""
-    sbp_platform = Platform.get_by_id(PlatformEnum.SBP, db_session)
-    if sbp_platform is None:
-        logger.warning("SBP platform not found; skipping admin notification email")
-        return
-
-    admin_emails = sbp_platform.get_admins(auth0_client=auth0_client)
-    if not admin_emails:
-        logger.info("No SBP platform admins found; skipping notification email")
-        return
-
-    subject, body_html = compose_sbp_registration_email(registration, settings)
-    for email in admin_emails:
-        enqueue_email(
-            db_session,
-            to_address=email,
-            subject=subject,
-            body_html=body_html,
-            settings=settings,
-        )
 
 
 @router.post(
@@ -137,17 +93,9 @@ async def register_sbp_user(
             session=db_session,
             request_reason=registration.request_reason,
         )
-
-        # Queue approval email for SBP platform admins
-        queue_sbp_admin_notifications(
-            registration=registration,
-            db_session=db_session,
-            auth0_client=auth0_client,
-            settings=settings,
-        )
         db_session.commit()
 
-        return {"message": "User registered successfully. Approval pending.", "user": auth0_user_data.model_dump(mode="json")}
+        return {"message": "User registered successfully.", "user": auth0_user_data.model_dump(mode="json")}
 
     # Return HTTP status errors as RegistrationErrorResponse
     except HTTPStatusError as e:
@@ -197,7 +145,7 @@ def _create_sbp_user_record(
         platform=PlatformEnum.SBP,
         db_session=session,
         auth0_client=auth0_client,
-        auto_approve=False,
+        auto_approve=True,
         request_reason=request_reason,
     )
     session.add(db_user)

--- a/tests/test_sbp_register.py
+++ b/tests/test_sbp_register.py
@@ -5,17 +5,14 @@ from sqlmodel import select
 from db.models import (
     BiocommonsUser,
     BiocommonsUserHistory,
-    EmailNotification,
     PlatformEnum,
     PlatformMembership,
     PlatformMembershipHistory,
 )
-from db.types import EmailStatusEnum
 from routers.sbp_register import validate_sbp_email_domain
 from schemas.biocommons import BiocommonsRegisterData
 from tests.datagen import (
     Auth0UserDataFactory,
-    RoleUserDataFactory,
     SBPRegistrationDataFactory,
     random_auth0_id,
 )
@@ -95,19 +92,11 @@ def test_successful_registration(
         email=valid_registration_data["email"],
         username=valid_registration_data["username"]
     )
-    admin_user = RoleUserDataFactory.build(email="sbp.admin@example.com")
-
-    def _get_all_role_users(*, role_id):
-        if role_id == sbp_platform.admin_roles[0].id:
-            return [admin_user]
-        raise AssertionError(f"Unexpected role id {role_id}")
-
-    mock_auth0_client.get_all_role_users.side_effect = _get_all_role_users
 
     response = test_client.post("/sbp/register", json=valid_registration_data)
 
     assert response.status_code == 200
-    assert "Approval pending" in response.json()["message"]
+    assert response.json()["message"] == "User registered successfully."
 
     user = test_db_session.get(BiocommonsUser, user_id)
     assert user is not None
@@ -121,7 +110,7 @@ def test_successful_registration(
         )
     ).first()
     assert membership is not None
-    assert membership.approval_status == "pending"
+    assert membership.approval_status == "approved"
 
     history = test_db_session.exec(
         select(PlatformMembershipHistory).where(
@@ -130,15 +119,14 @@ def test_successful_registration(
         )
     ).first()
     assert history is not None
-    assert history.approval_status == "pending"
+    assert history.approval_status == "approved"
 
     called_data = mock_auth0_client.create_user.call_args[0][0]
     assert called_data.user_metadata.sbp.registration_reason == valid_registration_data["request_reason"]
     assert called_data.app_metadata.registration_from == "sbp"
-    queued_emails = test_db_session.exec(select(EmailNotification)).all()
-    assert len(queued_emails) == 1
-    assert queued_emails[0].to_address == admin_user.email
-    assert queued_emails[0].status == EmailStatusEnum.PENDING
+
+    # Auth0 role should be granted immediately on registration
+    assert mock_auth0_client.add_roles_to_user.called
 
 
 def test_registration_duplicate_user(


### PR DESCRIPTION
## Description

[AAI-705](https://biocloud.atlassian.net/browse/AAI-705): enable automatic sbp platform for users

## Changes

- Changed `auto_approve=False` → `auto_approve=True` in `_create_sbp_user_record` — SBP users now get their Auth0 role granted immediately at registration
- Removed the `queue_sbp_admin_notifications()` call and the `db_session.commit()` is now right after user creation
- Updated success response message from "User registered successfully. Approval pending." → "User registered successfully."
- Removed dead code: `compose_sbp_registration_email`, `queue_sbp_admin_notifications functions`, and the `enqueue_email import`

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit / integration tests that prove my fix is effective or that my feature works
- [x] I have run all tests locally and they pass
- [x] I have updated the documentation (if applicable)
- [ ] For any new secrets, I have updated the [shared spreadsheet](https://docs.google.com/spreadsheets/d/16lGloFh4VxMmu6cJdeFVLy2654hdq-ZeErhB8UifSfI/edit?usp=sharing) and the [GitHub Secrets](https://github.com/AustralianBioCommons/aai-backend/settings/secrets/actions).

## How to Test Manually (if necessary)


```
uv run pytest
```

[AAI-705]: https://biocloud.atlassian.net/browse/AAI-705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ