### PR TITLE
feat: add bundle for SBP access (AAI-706)

### DIFF
--- a/biocommons/bundles.py
+++ b/biocommons/bundles.py
@@ -11,7 +11,7 @@ from db.types import GroupEnum, PlatformEnum
 logger = getLogger(__name__)
 
 # All new bundles should be added here
-BundleType = Literal["tsi"]
+BundleType = Literal["tsi", "sbp"]
 
 
 class BiocommonsBundle(BaseModel):

--- a/biocommons/bundles.py
+++ b/biocommons/bundles.py
@@ -11,7 +11,7 @@ from db.types import GroupEnum, PlatformEnum
 logger = getLogger(__name__)
 
 # All new bundles should be added here
-BundleType = Literal["tsi", "sbp"]
+BundleType = Literal["tsi", "sbp-bundle"]
 
 
 class BiocommonsBundle(BaseModel):

--- a/biocommons/bundles.py
+++ b/biocommons/bundles.py
@@ -11,7 +11,7 @@ from db.types import GroupEnum, PlatformEnum
 logger = getLogger(__name__)
 
 # All new bundles should be added here
-BundleType = Literal["tsi", "sbp-bundle"]
+BundleType = Literal["tsi", "sbp_bundle"]
 
 
 class BiocommonsBundle(BaseModel):
@@ -65,8 +65,8 @@ BUNDLES: dict[BundleType, BiocommonsBundle] = {
         group_auto_approve=False,
         extra_platforms=[],
     ),
-    "sbp-bundle": BiocommonsBundle(
-        id="sbp-bundle",
+    "sbp_bundle": BiocommonsBundle(
+        id="sbp_bundle",
         group_id=GroupEnum.SBP,
         # TODO: auto-approve based on domain?
         group_auto_approve=False,

--- a/biocommons/bundles.py
+++ b/biocommons/bundles.py
@@ -65,4 +65,11 @@ BUNDLES: dict[BundleType, BiocommonsBundle] = {
         group_auto_approve=False,
         extra_platforms=[],
     ),
+    "sbp-bundle": BiocommonsBundle(
+        id="sbp-bundle",
+        group_id=GroupEnum.SBP,
+        # TODO: auto-approve based on domain?
+        group_auto_approve=False,
+        extra_platforms=[],
+    )
 }

--- a/db/types.py
+++ b/db/types.py
@@ -78,7 +78,7 @@ class GroupMembershipData(BaseModel):
 
 class GroupEnum(str, Enum):
     TSI = "biocommons/group/tsi"
-    SBP = "biocommons/group/sbp-bundle"
+    SBP = "biocommons/group/sbp_bundle"
 
 
 # Provide default group names so we can populate the DB easily

--- a/db/types.py
+++ b/db/types.py
@@ -78,10 +78,12 @@ class GroupMembershipData(BaseModel):
 
 class GroupEnum(str, Enum):
     TSI = "biocommons/group/tsi"
+    SBP = "biocommons/group/sbp-bundle"
 
 
 # Provide default group names so we can populate the DB easily
 #   - should use the DB values when looking them up though
 GROUP_NAMES: dict[GroupEnum, tuple[str, str]] = {
     GroupEnum.TSI: ("Threatened Species Initiative", "TSI"),
+    GroupEnum.SBP: ("Structural Biology Platform Bundle", "SBP"),
 }

--- a/migrations/versions/98e639b5731f_sbp_group.py
+++ b/migrations/versions/98e639b5731f_sbp_group.py
@@ -1,0 +1,100 @@
+"""sbp_group: ensure SBP group exists in the DB
+
+Revision ID: 98e639b5731f
+Revises: 038392d88518
+Create Date: 2026-05-01 10:06:15.256398
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel
+
+SBP_GROUP_ID = "biocommons/group/sbp-bundle"
+SBP_NAME = "Structural Biology Platform Bundle"
+SBP_SHORT_NAME = "SBP"
+
+revision: str = '98e639b5731f'
+down_revision: Union[str, None] = '038392d88518'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    dialect = bind.dialect.name
+
+    if dialect == "postgresql":
+        bind.execute(
+            sa.text(
+                """
+                INSERT INTO biocommonsgroup (group_id, name, short_name, is_deleted)
+                VALUES (:group_id, :name, :short_name, FALSE)
+                ON CONFLICT (group_id) DO UPDATE
+                SET name = EXCLUDED.name,
+                    short_name = EXCLUDED.short_name,
+                    is_deleted = FALSE
+                """
+            ),
+            {
+                "group_id": SBP_GROUP_ID,
+                "name": SBP_NAME,
+                "short_name": SBP_SHORT_NAME,
+            },
+        )
+    else:
+        existing = bind.execute(
+            sa.text(
+                "SELECT group_id FROM biocommonsgroup WHERE group_id = :group_id"
+            ),
+            {"group_id": SBP_GROUP_ID},
+        ).fetchone()
+
+        if existing is None:
+            bind.execute(
+                sa.text(
+                    """
+                    INSERT INTO biocommonsgroup (group_id, name, short_name, is_deleted)
+                    VALUES (:group_id, :name, :short_name, FALSE)
+                    """
+                ),
+                {
+                    "group_id": SBP_GROUP_ID,
+                    "name": SBP_NAME,
+                    "short_name": SBP_SHORT_NAME,
+                },
+            )
+        else:
+            bind.execute(
+                sa.text(
+                    """
+                    UPDATE biocommonsgroup
+                    SET name       = :name,
+                        short_name = :short_name,
+                        is_deleted = FALSE
+                    WHERE group_id = :group_id
+                    """
+                ),
+                {
+                    "group_id": SBP_GROUP_ID,
+                    "name": SBP_NAME,
+                    "short_name": SBP_SHORT_NAME,
+                },
+            )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    # Soft-delete to avoid breaking memberships
+    bind.execute(
+        sa.text(
+            """
+            UPDATE biocommonsgroup
+            SET is_deleted = TRUE
+            WHERE group_id = :group_id
+            """
+        ),
+        {"group_id": SBP_GROUP_ID},
+    )
+

--- a/migrations/versions/98e639b5731f_sbp_group.py
+++ b/migrations/versions/98e639b5731f_sbp_group.py
@@ -11,7 +11,7 @@ from alembic import op
 import sqlalchemy as sa
 import sqlmodel
 
-SBP_GROUP_ID = "biocommons/group/sbp-bundle"
+SBP_GROUP_ID = "biocommons/group/sbp_bundle"
 SBP_NAME = "Structural Biology Platform Bundle"
 SBP_SHORT_NAME = "SBP"
 

--- a/routers/admin.py
+++ b/routers/admin.py
@@ -27,6 +27,7 @@ from auth.user_permissions import (
     user_is_general_admin,
 )
 from auth0.client import Auth0Client, UpdateUserData, get_auth0_client
+from biocommons.bundles import BundleType
 from biocommons.emails import (
     compose_email_change_notification,
     compose_group_membership_approved_email,
@@ -71,8 +72,9 @@ PLATFORM_MAPPING = {
     "sbp": {"enum": PlatformEnum.SBP, "name": "Structural Biology Platform"},
 }
 
-GROUP_MAPPING = {
+GROUP_MAPPING: dict[BundleType, dict] = {
     "tsi": {"enum": GroupEnum.TSI, "name": "Threatened Species Initiative"},
+    "sbp-bundle": {"enum": GroupEnum.SBP, "name": "Structural Biology Platform Bundle"},
 }
 
 

--- a/routers/admin.py
+++ b/routers/admin.py
@@ -74,7 +74,7 @@ PLATFORM_MAPPING = {
 
 GROUP_MAPPING: dict[BundleType, dict] = {
     "tsi": {"enum": GroupEnum.TSI, "name": "Threatened Species Initiative"},
-    "sbp-bundle": {"enum": GroupEnum.SBP, "name": "Structural Biology Platform Bundle"},
+    "sbp_bundle": {"enum": GroupEnum.SBP, "name": "Structural Biology Platform Bundle"},
 }
 
 

--- a/tests/admin_api/test_admin.py
+++ b/tests/admin_api/test_admin.py
@@ -20,7 +20,7 @@ from db.models import (
 )
 from db.types import ApprovalStatusEnum, EmailStatusEnum, GroupEnum, PlatformEnum
 from main import app
-from routers.admin import PaginationParams, UserQueryParams
+from routers.admin import GROUP_MAPPING, PLATFORM_MAPPING, PaginationParams, UserQueryParams
 from schemas.biocommons import Auth0Identity
 from tests.biocommons.datagen import RoleDataFactory
 from tests.datagen import (
@@ -107,6 +107,13 @@ def test_pagination_params_start_index():
     params = PaginationParams(page=2, per_page=10)
     # start index for page 1 is 0, for page 2 is 0 + per_page = 10
     assert params.start_index == 10
+
+
+def test_group_and_platform_mapping_ids_do_not_overlap():
+    assert PLATFORM_MAPPING.keys().isdisjoint(GROUP_MAPPING.keys()), (
+        "Admin platform and group mapping IDs must not overlap: "
+        f"{sorted(PLATFORM_MAPPING.keys() & GROUP_MAPPING.keys())}"
+    )
 
 
 def test_get_users_requires_admin_unauthorized(test_client, test_db_session):
@@ -453,7 +460,7 @@ def test_get_filter_options(test_client, as_admin_user, test_db_session, persist
 
     options = resp.json()
     assert isinstance(options, list)
-    assert len(options) == 4
+    assert len(options) == 5
 
     for option in options:
         assert "id" in option
@@ -462,13 +469,14 @@ def test_get_filter_options(test_client, as_admin_user, test_db_session, persist
         assert isinstance(option["name"], str)
 
     option_ids = {opt["id"] for opt in options}
-    expected_ids = {"galaxy", "bpa_data_portal", "sbp", "tsi"}
+    expected_ids = {"galaxy", "bpa_data_portal", "sbp", "tsi", "sbp-bundle"}
     assert option_ids == expected_ids
 
     option_dict = {opt["id"]: opt["name"] for opt in options}
     assert option_dict["galaxy"] == "Galaxy Australia"
     assert option_dict["bpa_data_portal"] == "Bioplatforms Australia Data Portal"
     assert option_dict["sbp"] == "Structural Biology Platform"
+    assert option_dict["sbp-bundle"] == "Structural Biology Platform Bundle"
     assert option_dict["tsi"] == "Threatened Species Initiative"
 
 

--- a/tests/admin_api/test_admin.py
+++ b/tests/admin_api/test_admin.py
@@ -474,14 +474,14 @@ def test_get_filter_options(test_client, as_admin_user, test_db_session, persist
         assert isinstance(option["name"], str)
 
     option_ids = {opt["id"] for opt in options}
-    expected_ids = {"galaxy", "bpa_data_portal", "sbp", "tsi", "sbp-bundle"}
+    expected_ids = {"galaxy", "bpa_data_portal", "sbp", "tsi", "sbp_bundle"}
     assert option_ids == expected_ids
 
     option_dict = {opt["id"]: opt["name"] for opt in options}
     assert option_dict["galaxy"] == "Galaxy Australia"
     assert option_dict["bpa_data_portal"] == "Bioplatforms Australia Data Portal"
     assert option_dict["sbp"] == "Structural Biology Platform"
-    assert option_dict["sbp-bundle"] == "Structural Biology Platform Bundle"
+    assert option_dict["sbp_bundle"] == "Structural Biology Platform Bundle"
     assert option_dict["tsi"] == "Threatened Species Initiative"
 
 

--- a/tests/admin_api/test_admin.py
+++ b/tests/admin_api/test_admin.py
@@ -20,7 +20,12 @@ from db.models import (
 )
 from db.types import ApprovalStatusEnum, EmailStatusEnum, GroupEnum, PlatformEnum
 from main import app
-from routers.admin import GROUP_MAPPING, PLATFORM_MAPPING, PaginationParams, UserQueryParams
+from routers.admin import (
+    GROUP_MAPPING,
+    PLATFORM_MAPPING,
+    PaginationParams,
+    UserQueryParams,
+)
 from schemas.biocommons import Auth0Identity
 from tests.biocommons.datagen import RoleDataFactory
 from tests.datagen import (

--- a/tests/db/test_types.py
+++ b/tests/db/test_types.py
@@ -1,0 +1,14 @@
+from db.types import GroupEnum, PlatformEnum
+
+
+def test_group_and_platform_ids_do_not_overlap():
+    platform_ids = {platform.value for platform in PlatformEnum}
+    group_ids = {
+        group.value.removeprefix("biocommons/group/")
+        for group in GroupEnum
+    }
+
+    assert platform_ids.isdisjoint(group_ids), (
+        "Group IDs must not overlap platform IDs: "
+        f"{sorted(platform_ids & group_ids)}"
+    )

--- a/tests/migrations/test_migrations.py
+++ b/tests/migrations/test_migrations.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+from alembic import command
+from alembic.config import Config
+from sqlmodel import Session, create_engine
+
+from db.models import BiocommonsGroup
+
+
+def test_sbp_group_migration_creates_expected_group(tmp_path, mocker):
+    db_path = tmp_path / "sbp_group_migration.sqlite"
+    db_url = f"sqlite:///{db_path}"
+
+    mocker.patch("db.setup.get_db_config", return_value=(db_url, {"check_same_thread": False}))
+
+    repo_root = Path(__file__).resolve().parents[2]
+    alembic_config = Config(str(repo_root / "alembic.ini"))
+
+    command.upgrade(alembic_config, "98e639b5731f")
+
+    engine = create_engine(
+        db_url,
+        connect_args={"check_same_thread": False},
+    )
+    try:
+        with Session(engine) as session:
+            group = session.get(BiocommonsGroup, "biocommons/group/sbp-bundle")
+            assert group is not None
+            assert group.group_id == "biocommons/group/sbp-bundle"
+            assert group.name == "Structural Biology Platform Bundle"
+            assert group.short_name == "SBP"
+            assert group.is_deleted is False
+    finally:
+        engine.dispose()

--- a/tests/migrations/test_migrations.py
+++ b/tests/migrations/test_migrations.py
@@ -24,9 +24,9 @@ def test_sbp_group_migration_creates_expected_group(tmp_path, mocker):
     )
     try:
         with Session(engine) as session:
-            group = session.get(BiocommonsGroup, "biocommons/group/sbp-bundle")
+            group = session.get(BiocommonsGroup, "biocommons/group/sbp_bundle")
             assert group is not None
-            assert group.group_id == "biocommons/group/sbp-bundle"
+            assert group.group_id == "biocommons/group/sbp_bundle"
             assert group.name == "Structural Biology Platform Bundle"
             assert group.short_name == "SBP"
             assert group.is_deleted is False

--- a/tests/scheduled_tasks/test_tasks.py
+++ b/tests/scheduled_tasks/test_tasks.py
@@ -656,7 +656,7 @@ async def test_populate_db_groups_adds_sbp_with_expected_metadata(
 
     await populate_db_groups()
 
-    sbp_group = test_db_session.get(BiocommonsGroup, "biocommons/group/sbp-bundle")
+    sbp_group = test_db_session.get(BiocommonsGroup, "biocommons/group/sbp_bundle")
     assert sbp_group is not None
     assert sbp_group.name == "Structural Biology Platform Bundle"
     assert sbp_group.short_name == "SBP"

--- a/tests/scheduled_tasks/test_tasks.py
+++ b/tests/scheduled_tasks/test_tasks.py
@@ -645,6 +645,24 @@ async def test_populate_db_groups_only_adds_missing(test_db_session, mocker, moc
 
 
 @pytest.mark.asyncio
+async def test_populate_db_groups_adds_sbp_with_expected_metadata(
+    test_db_session, mocker, mock_settings, persistent_factories
+):
+    mocker.patch("scheduled_tasks.tasks.get_settings", return_value=mock_settings)
+    mocker.patch(
+        "scheduled_tasks.tasks.get_db_session",
+        return_value=_task_session_iter(test_db_session.get_bind()),
+    )
+
+    await populate_db_groups()
+
+    sbp_group = test_db_session.get(BiocommonsGroup, "biocommons/group/sbp-bundle")
+    assert sbp_group is not None
+    assert sbp_group.name == "Structural Biology Platform Bundle"
+    assert sbp_group.short_name == "SBP"
+
+
+@pytest.mark.asyncio
 async def test_sync_auth0_platform_roles(mocker, test_db_session, mock_settings, persistent_factories):
     """
     User-role assignments from Auth0 are mirrored in the database and stale assignments are soft deleted.


### PR DESCRIPTION
## Description

[AAI-706](https://biocloud.atlassian.net/browse/AAI-706): add an SBP bundle to determine access to SBP workflows

## Changes

- Add a group with ID `sbp_bundle` to the types and mappings that define bundles
- Add a migration so the group is automatically created
- Test group creation, and ensure group/platform IDs are unique (we don't want both a group and platform with ID `sbp`)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit / integration tests that prove my fix is effective or that my feature works
- [x] I have run all tests locally and they pass
- [x] I have updated the documentation (if applicable)
- [ ] For any new secrets, I have updated the [shared spreadsheet](https://docs.google.com/spreadsheets/d/16lGloFh4VxMmu6cJdeFVLy2654hdq-ZeErhB8UifSfI/edit?usp=sharing) and the [GitHub Secrets](https://github.com/AustralianBioCommons/aai-backend/settings/secrets/actions).

## How to Test Manually (if necessary)

Run `uv run pytest`


[AAI-706]: https://biocloud.atlassian.net/browse/AAI-706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ