### PR TITLE
feat: add SBP bundle and enable auto register to SBP platform membership

### DIFF
--- a/biocommons/bundles.py
+++ b/biocommons/bundles.py
@@ -11,7 +11,7 @@ from db.types import GroupEnum, PlatformEnum
 logger = getLogger(__name__)
 
 # All new bundles should be added here
-BundleType = Literal["tsi", "sbp_bundle"]
+BundleType = Literal["tsi", "sbp_workflow_execution"]
 
 
 class BiocommonsBundle(BaseModel):
@@ -65,8 +65,8 @@ BUNDLES: dict[BundleType, BiocommonsBundle] = {
         group_auto_approve=False,
         extra_platforms=[],
     ),
-    "sbp_bundle": BiocommonsBundle(
-        id="sbp_bundle",
+    "sbp_workflow_execution": BiocommonsBundle(
+        id="sbp_workflow_execution",
         group_id=GroupEnum.SBP,
         # TODO: auto-approve based on domain?
         group_auto_approve=False,

--- a/biocommons/emails.py
+++ b/biocommons/emails.py
@@ -371,6 +371,31 @@ def compose_group_membership_rejected_email(
     return subject, _wrap_email_html(subject, subject, body_content, portal_url)
 
 
+def compose_group_membership_rejected_generic_email(
+    *,
+    group_name: str,
+    username: str,
+    settings: Settings,
+) -> tuple[str, str]:
+    """
+    Notify a user that their group/bundle access request was rejected.
+    Generic version for non-TSI groups.
+    """
+    portal_url = settings.aai_portal_url or ""
+    safe_group_name = html.escape(group_name or "")
+    safe_username = html.escape(username or "")
+    subject = f"{group_name} service bundle request"
+    body_content = f"""
+        <p style="{_P}">Dear {safe_username},</p>
+        <p style="{_P}">Thank you for your interest in the {safe_group_name} Bundle.</p>
+        <p style="{_P}">Unfortunately, your request for access has not been approved at this time.</p>
+        <p style="{_P}">If you have any questions, please <a href="https://biocommonsaccess.freshdesk.com/support/home" target="_blank" rel="noopener noreferrer" style="{_A}">contact support</a>.</p>
+        <p style="{_P_SIGN_OFF}">Thank you,</p>
+        <p style="{_P}">BioCommons Access Team</p>
+    """
+    return subject, _wrap_email_html(subject, subject, body_content, portal_url)
+
+
 def compose_bundle_request_confirmation_email(
     *,
     first_name: str,

--- a/biocommons/emails.py
+++ b/biocommons/emails.py
@@ -371,31 +371,6 @@ def compose_group_membership_rejected_email(
     return subject, _wrap_email_html(subject, subject, body_content, portal_url)
 
 
-def compose_group_membership_rejected_generic_email(
-    *,
-    group_name: str,
-    username: str,
-    settings: Settings,
-) -> tuple[str, str]:
-    """
-    Notify a user that their group/bundle access request was rejected.
-    Generic version for non-TSI groups.
-    """
-    portal_url = settings.aai_portal_url or ""
-    safe_group_name = html.escape(group_name or "")
-    safe_username = html.escape(username or "")
-    subject = f"{group_name} service bundle request"
-    body_content = f"""
-        <p style="{_P}">Dear {safe_username},</p>
-        <p style="{_P}">Thank you for your interest in the {safe_group_name} Bundle.</p>
-        <p style="{_P}">Unfortunately, your request for access has not been approved at this time.</p>
-        <p style="{_P}">If you have any questions, please <a href="https://biocommonsaccess.freshdesk.com/support/home" target="_blank" rel="noopener noreferrer" style="{_A}">contact support</a>.</p>
-        <p style="{_P_SIGN_OFF}">Thank you,</p>
-        <p style="{_P}">BioCommons Access Team</p>
-    """
-    return subject, _wrap_email_html(subject, subject, body_content, portal_url)
-
-
 def compose_bundle_request_confirmation_email(
     *,
     first_name: str,

--- a/db/types.py
+++ b/db/types.py
@@ -78,7 +78,7 @@ class GroupMembershipData(BaseModel):
 
 class GroupEnum(str, Enum):
     TSI = "biocommons/group/tsi"
-    SBP = "biocommons/group/sbp_bundle"
+    SBP = "biocommons/group/sbp_workflow_execution"
 
 
 # Provide default group names so we can populate the DB easily

--- a/migrations/versions/98e639b5731f_sbp_group.py
+++ b/migrations/versions/98e639b5731f_sbp_group.py
@@ -11,7 +11,7 @@ from alembic import op
 import sqlalchemy as sa
 import sqlmodel
 
-SBP_GROUP_ID = "biocommons/group/sbp_bundle"
+SBP_GROUP_ID = "biocommons/group/sbp_workflow_execution"
 SBP_NAME = "Structural Biology Platform Bundle"
 SBP_SHORT_NAME = "SBP"
 

--- a/routers/admin.py
+++ b/routers/admin.py
@@ -70,6 +70,7 @@ logger = logging.getLogger('uvicorn.error')
 PLATFORM_MAPPING = {
     "galaxy": {"enum": PlatformEnum.GALAXY, "name": "Galaxy Australia"},
     "bpa_data_portal": {"enum": PlatformEnum.BPA_DATA_PORTAL, "name": "Bioplatforms Australia Data Portal"},
+    "sbp": {"enum": PlatformEnum.SBP, "name": "Structural Biology Platform"},
 }
 
 GROUP_MAPPING: dict[BundleType, dict] = {

--- a/routers/admin.py
+++ b/routers/admin.py
@@ -74,7 +74,7 @@ PLATFORM_MAPPING = {
 
 GROUP_MAPPING: dict[BundleType, dict] = {
     "tsi": {"enum": GroupEnum.TSI, "name": "Threatened Species Initiative"},
-    "sbp_bundle": {"enum": GroupEnum.SBP, "name": "Structural Biology Platform Bundle"},
+    "sbp_workflow_execution": {"enum": GroupEnum.SBP, "name": "Structural Biology Platform Bundle"},
 }
 
 

--- a/routers/admin.py
+++ b/routers/admin.py
@@ -32,7 +32,6 @@ from biocommons.emails import (
     compose_email_change_notification,
     compose_group_membership_approved_email,
     compose_group_membership_rejected_email,
-    compose_group_membership_rejected_generic_email,
     compose_username_change_notification,
     format_first_name,
 )
@@ -1270,19 +1269,12 @@ def reject_group_membership(user_id: Annotated[str, UserIdParam],
         session=db_session,
         commit=False,
     )
-    if membership.user and membership.user.email:
-        if group_id == GroupEnum.TSI.value:
-            subject, body_html = compose_group_membership_rejected_email(
-                group_name=group_record.name,
-                username=membership.user.username,
-                settings=settings,
-            )
-        else:
-            subject, body_html = compose_group_membership_rejected_generic_email(
-                group_name=group_record.name,
-                username=membership.user.username,
-                settings=settings,
-            )
+    if membership.user and membership.user.email and group_id == GroupEnum.TSI.value:
+        subject, body_html = compose_group_membership_rejected_email(
+            group_name=group_record.name,
+            username=membership.user.username,
+            settings=settings,
+        )
         enqueue_email(
             session=db_session,
             to_address=membership.user.email,

--- a/routers/admin.py
+++ b/routers/admin.py
@@ -32,6 +32,7 @@ from biocommons.emails import (
     compose_email_change_notification,
     compose_group_membership_approved_email,
     compose_group_membership_rejected_email,
+    compose_group_membership_rejected_generic_email,
     compose_username_change_notification,
     format_first_name,
 )
@@ -69,7 +70,6 @@ logger = logging.getLogger('uvicorn.error')
 PLATFORM_MAPPING = {
     "galaxy": {"enum": PlatformEnum.GALAXY, "name": "Galaxy Australia"},
     "bpa_data_portal": {"enum": PlatformEnum.BPA_DATA_PORTAL, "name": "Bioplatforms Australia Data Portal"},
-    "sbp": {"enum": PlatformEnum.SBP, "name": "Structural Biology Platform"},
 }
 
 GROUP_MAPPING: dict[BundleType, dict] = {
@@ -1269,12 +1269,19 @@ def reject_group_membership(user_id: Annotated[str, UserIdParam],
         session=db_session,
         commit=False,
     )
-    if group_id == GroupEnum.TSI.value and membership.user and membership.user.email:
-        subject, body_html = compose_group_membership_rejected_email(
-            group_name=group_record.name,
-            username=membership.user.username,
-            settings=settings,
-        )
+    if membership.user and membership.user.email:
+        if group_id == GroupEnum.TSI.value:
+            subject, body_html = compose_group_membership_rejected_email(
+                group_name=group_record.name,
+                username=membership.user.username,
+                settings=settings,
+            )
+        else:
+            subject, body_html = compose_group_membership_rejected_generic_email(
+                group_name=group_record.name,
+                username=membership.user.username,
+                settings=settings,
+            )
         enqueue_email(
             session=db_session,
             to_address=membership.user.email,

--- a/routers/sbp_register.py
+++ b/routers/sbp_register.py
@@ -10,8 +10,8 @@ from auth0.client import Auth0Client, get_auth0_client
 from biocommons.bundles import BUNDLES
 from config import Settings, get_settings
 from db.models import BiocommonsUser, BiocommonsUserHistory
-from db.types import PlatformEnum
 from db.setup import get_db_session
+from db.types import PlatformEnum
 from routers.errors import RegistrationRoute
 from routers.utils import check_existing_user
 from schemas.biocommons import Auth0UserData, BiocommonsRegisterData

--- a/routers/sbp_register.py
+++ b/routers/sbp_register.py
@@ -7,8 +7,9 @@ from sqlmodel import Session
 from starlette.responses import JSONResponse, Response
 
 from auth0.client import Auth0Client, get_auth0_client
+from biocommons.bundles import BUNDLES
 from config import Settings, get_settings
-from db.models import BiocommonsUser, BiocommonsUserHistory, PlatformEnum
+from db.models import BiocommonsUser, BiocommonsUserHistory
 from db.setup import get_db_session
 from routers.errors import RegistrationRoute
 from routers.utils import check_existing_user
@@ -141,14 +142,13 @@ def _create_sbp_user_record(
     request_reason: str | None = None,
 ) -> BiocommonsUser:
     db_user = BiocommonsUser.from_auth0_data(data=auth0_user_data)
-    sbp_membership = db_user.add_platform_membership(
-        platform=PlatformEnum.SBP,
-        db_session=session,
+    session.add(db_user)
+    session.flush()
+    BUNDLES["sbp_bundle"].create_memberships(
+        user=db_user,
         auth0_client=auth0_client,
-        auto_approve=True,
+        db_session=session,
+        commit=False,
         request_reason=request_reason,
     )
-    session.add(db_user)
-    session.add(sbp_membership)
-    session.flush()
     return db_user

--- a/routers/sbp_register.py
+++ b/routers/sbp_register.py
@@ -10,6 +10,7 @@ from auth0.client import Auth0Client, get_auth0_client
 from biocommons.bundles import BUNDLES
 from config import Settings, get_settings
 from db.models import BiocommonsUser, BiocommonsUserHistory
+from db.types import PlatformEnum
 from db.setup import get_db_session
 from routers.errors import RegistrationRoute
 from routers.utils import check_existing_user
@@ -144,6 +145,14 @@ def _create_sbp_user_record(
     db_user = BiocommonsUser.from_auth0_data(data=auth0_user_data)
     session.add(db_user)
     session.flush()
+    # Auto-approve SBP platform membership so the user can log into the platform immediately
+    sbp_membership = db_user.add_platform_membership(
+        platform=PlatformEnum.SBP,
+        db_session=session,
+        auth0_client=auth0_client,
+        auto_approve=True,
+    )
+    session.add(sbp_membership)
     BUNDLES["sbp_bundle"].create_memberships(
         user=db_user,
         auth0_client=auth0_client,

--- a/routers/sbp_register.py
+++ b/routers/sbp_register.py
@@ -153,7 +153,7 @@ def _create_sbp_user_record(
         auto_approve=True,
     )
     session.add(sbp_membership)
-    BUNDLES["sbp_bundle"].create_memberships(
+    BUNDLES["sbp_workflow_execution"].create_memberships(
         user=db_user,
         auth0_client=auth0_client,
         db_session=session,

--- a/tests/admin_api/test_admin.py
+++ b/tests/admin_api/test_admin.py
@@ -465,7 +465,7 @@ def test_get_filter_options(test_client, as_admin_user, test_db_session, persist
 
     options = resp.json()
     assert isinstance(options, list)
-    assert len(options) == 4
+    assert len(options) == 5
 
     for option in options:
         assert "id" in option
@@ -474,12 +474,13 @@ def test_get_filter_options(test_client, as_admin_user, test_db_session, persist
         assert isinstance(option["name"], str)
 
     option_ids = {opt["id"] for opt in options}
-    expected_ids = {"galaxy", "bpa_data_portal", "tsi", "sbp_bundle"}
+    expected_ids = {"galaxy", "bpa_data_portal", "sbp", "tsi", "sbp_bundle"}
     assert option_ids == expected_ids
 
     option_dict = {opt["id"]: opt["name"] for opt in options}
     assert option_dict["galaxy"] == "Galaxy Australia"
     assert option_dict["bpa_data_portal"] == "Bioplatforms Australia Data Portal"
+    assert option_dict["sbp"] == "Structural Biology Platform"
     assert option_dict["sbp_bundle"] == "Structural Biology Platform Bundle"
     assert option_dict["tsi"] == "Threatened Species Initiative"
 

--- a/tests/admin_api/test_admin.py
+++ b/tests/admin_api/test_admin.py
@@ -474,14 +474,14 @@ def test_get_filter_options(test_client, as_admin_user, test_db_session, persist
         assert isinstance(option["name"], str)
 
     option_ids = {opt["id"] for opt in options}
-    expected_ids = {"galaxy", "bpa_data_portal", "sbp", "tsi", "sbp_bundle"}
+    expected_ids = {"galaxy", "bpa_data_portal", "sbp", "tsi", "sbp_workflow_execution"}
     assert option_ids == expected_ids
 
     option_dict = {opt["id"]: opt["name"] for opt in options}
     assert option_dict["galaxy"] == "Galaxy Australia"
     assert option_dict["bpa_data_portal"] == "Bioplatforms Australia Data Portal"
     assert option_dict["sbp"] == "Structural Biology Platform"
-    assert option_dict["sbp_bundle"] == "Structural Biology Platform Bundle"
+    assert option_dict["sbp_workflow_execution"] == "Structural Biology Platform Bundle"
     assert option_dict["tsi"] == "Threatened Species Initiative"
 
 

--- a/tests/admin_api/test_admin.py
+++ b/tests/admin_api/test_admin.py
@@ -465,7 +465,7 @@ def test_get_filter_options(test_client, as_admin_user, test_db_session, persist
 
     options = resp.json()
     assert isinstance(options, list)
-    assert len(options) == 5
+    assert len(options) == 4
 
     for option in options:
         assert "id" in option
@@ -474,13 +474,12 @@ def test_get_filter_options(test_client, as_admin_user, test_db_session, persist
         assert isinstance(option["name"], str)
 
     option_ids = {opt["id"] for opt in options}
-    expected_ids = {"galaxy", "bpa_data_portal", "sbp", "tsi", "sbp_bundle"}
+    expected_ids = {"galaxy", "bpa_data_portal", "tsi", "sbp_bundle"}
     assert option_ids == expected_ids
 
     option_dict = {opt["id"]: opt["name"] for opt in options}
     assert option_dict["galaxy"] == "Galaxy Australia"
     assert option_dict["bpa_data_portal"] == "Bioplatforms Australia Data Portal"
-    assert option_dict["sbp"] == "Structural Biology Platform"
     assert option_dict["sbp_bundle"] == "Structural Biology Platform Bundle"
     assert option_dict["tsi"] == "Threatened Species Initiative"
 

--- a/tests/migrations/test_migrations.py
+++ b/tests/migrations/test_migrations.py
@@ -24,9 +24,9 @@ def test_sbp_group_migration_creates_expected_group(tmp_path, mocker):
     )
     try:
         with Session(engine) as session:
-            group = session.get(BiocommonsGroup, "biocommons/group/sbp_bundle")
+            group = session.get(BiocommonsGroup, "biocommons/group/sbp_workflow_execution")
             assert group is not None
-            assert group.group_id == "biocommons/group/sbp_bundle"
+            assert group.group_id == "biocommons/group/sbp_workflow_execution"
             assert group.name == "Structural Biology Platform Bundle"
             assert group.short_name == "SBP"
             assert group.is_deleted is False

--- a/tests/scheduled_tasks/test_tasks.py
+++ b/tests/scheduled_tasks/test_tasks.py
@@ -656,7 +656,7 @@ async def test_populate_db_groups_adds_sbp_with_expected_metadata(
 
     await populate_db_groups()
 
-    sbp_group = test_db_session.get(BiocommonsGroup, "biocommons/group/sbp_bundle")
+    sbp_group = test_db_session.get(BiocommonsGroup, "biocommons/group/sbp_workflow_execution")
     assert sbp_group is not None
     assert sbp_group.name == "Structural Biology Platform Bundle"
     assert sbp_group.short_name == "SBP"

--- a/tests/test_sbp_register.py
+++ b/tests/test_sbp_register.py
@@ -6,8 +6,9 @@ from db.models import (
     BiocommonsUser,
     BiocommonsUserHistory,
     GroupMembership,
+    PlatformMembership,
 )
-from db.types import ApprovalStatusEnum, GroupEnum
+from db.types import ApprovalStatusEnum, GroupEnum, PlatformEnum
 from routers.sbp_register import validate_sbp_email_domain
 from schemas.biocommons import BiocommonsRegisterData
 from tests.datagen import (
@@ -19,6 +20,7 @@ from tests.db.datagen import (
     Auth0RoleFactory,
     BiocommonsGroupFactory,
     BiocommonsUserFactory,
+    PlatformFactory,
 )
 
 
@@ -33,6 +35,19 @@ def valid_registration_data(mock_settings):
         request_reason="Need access to SBP resources",
         password="SecurePass123!",
     ).model_dump()
+
+
+@pytest.fixture
+def sbp_platform(persistent_factories):
+    """
+    Set up the SBP platform with the associated platform role
+    """
+    platform_role = Auth0RoleFactory.create_sync(name="biocommons/platform/sbp")
+    return PlatformFactory.create_sync(
+        id=PlatformEnum.SBP,
+        role_id=platform_role.id,
+        name="Structural Biology Platform",
+    )
 
 
 @pytest.fixture
@@ -86,7 +101,7 @@ def test_validate_sbp_email_domain_function():
 
 
 def test_successful_registration(
-    test_client, valid_registration_data, mock_auth0_client, sbp_group, test_db_session
+    test_client, valid_registration_data, mock_auth0_client, sbp_group, sbp_platform, test_db_session
 ):
     user_id = random_auth0_id()
     mock_auth0_client.create_user.return_value = Auth0UserDataFactory.build(
@@ -105,21 +120,31 @@ def test_successful_registration(
     assert user.email == valid_registration_data["email"]
     assert user.username == valid_registration_data["username"]
 
-    membership = test_db_session.exec(
+    group_membership = test_db_session.exec(
         select(GroupMembership).where(
             GroupMembership.user_id == user_id,
             GroupMembership.group_id == GroupEnum.SBP.value,
         )
     ).first()
-    assert membership is not None
-    assert membership.approval_status == ApprovalStatusEnum.PENDING
+    assert group_membership is not None
+    assert group_membership.approval_status == ApprovalStatusEnum.PENDING
+
+    # SBP platform membership is auto-approved at registration so the user can log into the platform
+    platform_membership = test_db_session.exec(
+        select(PlatformMembership).where(
+            PlatformMembership.user_id == user_id,
+            PlatformMembership.platform_id == PlatformEnum.SBP,
+        )
+    ).first()
+    assert platform_membership is not None
+    assert platform_membership.approval_status == ApprovalStatusEnum.APPROVED
 
     called_data = mock_auth0_client.create_user.call_args[0][0]
     assert called_data.user_metadata.sbp.registration_reason == valid_registration_data["request_reason"]
     assert called_data.app_metadata.registration_from == "sbp"
 
-    # Auth0 role should NOT be granted until admin approves
-    assert not mock_auth0_client.add_roles_to_user.called
+    # Auth0 platform role is granted immediately; bundle role is not granted until admin approves
+    assert mock_auth0_client.add_roles_to_user.call_count == 1
 
 
 def test_registration_duplicate_user(

--- a/tests/test_sbp_register.py
+++ b/tests/test_sbp_register.py
@@ -5,10 +5,9 @@ from sqlmodel import select
 from db.models import (
     BiocommonsUser,
     BiocommonsUserHistory,
-    PlatformEnum,
-    PlatformMembership,
-    PlatformMembershipHistory,
+    GroupMembership,
 )
+from db.types import ApprovalStatusEnum, GroupEnum
 from routers.sbp_register import validate_sbp_email_domain
 from schemas.biocommons import BiocommonsRegisterData
 from tests.datagen import (
@@ -16,7 +15,11 @@ from tests.datagen import (
     SBPRegistrationDataFactory,
     random_auth0_id,
 )
-from tests.db.datagen import Auth0RoleFactory, BiocommonsUserFactory, PlatformFactory
+from tests.db.datagen import (
+    Auth0RoleFactory,
+    BiocommonsGroupFactory,
+    BiocommonsUserFactory,
+)
 
 
 @pytest.fixture
@@ -33,16 +36,15 @@ def valid_registration_data(mock_settings):
 
 
 @pytest.fixture
-def sbp_platform(persistent_factories):
+def sbp_group(persistent_factories):
     """
-    Set up a SBP platform with the associated platform role
+    Set up the SBP group with the associated admin role
     """
-    platform_role = Auth0RoleFactory.create_sync(name="biocommons/platform/sbp")
     admin_role = Auth0RoleFactory.create_sync(name="biocommons/role/sbp/admin")
-    return PlatformFactory.create_sync(
-        id=PlatformEnum.SBP,
-        role_id=platform_role.id,
-        name="Structural Biology Platform",
+    return BiocommonsGroupFactory.create_sync(
+        group_id=GroupEnum.SBP.value,
+        name="Structural Biology Platform Bundle",
+        short_name="SBP",
         admin_roles=[admin_role],
     )
 
@@ -84,7 +86,7 @@ def test_validate_sbp_email_domain_function():
 
 
 def test_successful_registration(
-    test_client, valid_registration_data, mock_auth0_client, sbp_platform, test_db_session
+    test_client, valid_registration_data, mock_auth0_client, sbp_group, test_db_session
 ):
     user_id = random_auth0_id()
     mock_auth0_client.create_user.return_value = Auth0UserDataFactory.build(
@@ -104,29 +106,20 @@ def test_successful_registration(
     assert user.username == valid_registration_data["username"]
 
     membership = test_db_session.exec(
-        select(PlatformMembership).where(
-            PlatformMembership.user_id == user_id,
-            PlatformMembership.platform_id == PlatformEnum.SBP
+        select(GroupMembership).where(
+            GroupMembership.user_id == user_id,
+            GroupMembership.group_id == GroupEnum.SBP.value,
         )
     ).first()
     assert membership is not None
-    assert membership.approval_status == "approved"
-
-    history = test_db_session.exec(
-        select(PlatformMembershipHistory).where(
-            PlatformMembershipHistory.user_id == user_id,
-            PlatformMembershipHistory.platform_id == PlatformEnum.SBP
-        )
-    ).first()
-    assert history is not None
-    assert history.approval_status == "approved"
+    assert membership.approval_status == ApprovalStatusEnum.PENDING
 
     called_data = mock_auth0_client.create_user.call_args[0][0]
     assert called_data.user_metadata.sbp.registration_reason == valid_registration_data["request_reason"]
     assert called_data.app_metadata.registration_from == "sbp"
 
-    # Auth0 role should be granted immediately on registration
-    assert mock_auth0_client.add_roles_to_user.called
+    # Auth0 role should NOT be granted until admin approves
+    assert not mock_auth0_client.add_roles_to_user.called
 
 
 def test_registration_duplicate_user(


### PR DESCRIPTION
## Description

[AAI-707](https://biocloud.atlassian.net/browse/AAI-707):  Switch SBP from platform management to bundle/group management

## Changes

- Removes SBP from `PLATFORM_MAPPING` in the admin router so SBP admins now manage users via the bundle/group admin flow instead of the platform flow. SBP remains accessible as a filter via `GROUP_MAPPING` under `sbp_bundle`.
- Updates SBP registration (`sbp_register.py`) to create a pending `GroupMembership` (via `BUNDLES["sbp_bundle"].create_memberships()`) instead of an auto-approved `PlatformMembership`. New SBP users now require admin approval before receiving access.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit / integration tests that prove my fix is effective or that my feature works
- [x] I have run all tests locally and they pass
- [x] I have updated the documentation (if applicable)
- [ ] For any new secrets, I have updated the [shared spreadsheet](https://docs.google.com/spreadsheets/d/16lGloFh4VxMmu6cJdeFVLy2654hdq-ZeErhB8UifSfI/edit?usp=sharing) and the [GitHub Secrets](https://github.com/AustralianBioCommons/aai-backend/settings/secrets/actions).


[AAI-707]: https://biocloud.atlassian.net/browse/AAI-707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ