### PR TITLE
fix: clean up incorrect group name/ID in DB

### DIFF
--- a/generate_migrations.py
+++ b/generate_migrations.py
@@ -37,7 +37,8 @@ def print_db_schema():
 @click.option('--revision-message', '-m', required=False, help="Message for Alembic revision.")
 @click.option('--check', is_flag=True, help="Only run 'alembic check' after DB container is up.")
 @click.option('--print-schema', is_flag=True, help="Print the schema of the database after upgrade/check.")
-def generate_migrations(revision_message, check, print_schema):
+@click.option('--autogenerate/--no-autogenerate', is_flag=True, default=True, help="use --no-autogenerate to create a blank migration")
+def generate_migrations(revision_message, check, print_schema, autogenerate):
     """Spin up a temp Postgres DB, apply migrations or run alembic check, optionally print schema."""
     if not check and not revision_message:
         raise click.UsageError("Missing option '-m' / '--revision-message'. Required unless using --check.")
@@ -68,7 +69,10 @@ def generate_migrations(revision_message, check, print_schema):
 
         elif revision_message:
             print("📝 Generating new Alembic revision...")
-            run(f'alembic revision --autogenerate -m "{revision_message}"')
+            if autogenerate:
+                run(f'alembic revision --autogenerate -m "{revision_message}"')
+            else:
+                run(f'alembic revision -m "{revision_message}"')
 
         if print_schema:
             print_db_schema()

--- a/migrations/versions/4000ecb2796d_cleanup_sbp_group.py
+++ b/migrations/versions/4000ecb2796d_cleanup_sbp_group.py
@@ -1,0 +1,108 @@
+"""cleanup_sbp_group
+
+Revision ID: 4000ecb2796d
+Revises: 274454823044
+Create Date: 2026-05-19 09:04:35.271199
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel
+
+
+# revision identifiers, used by Alembic.
+revision: str = '4000ecb2796d'
+down_revision: Union[str, None] = '274454823044'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+OLD_SBP_GROUP_ID = "biocommons/group/sbp_bundle"
+SBP_GROUP_ID = "biocommons/group/sbp_workflow_execution"
+SBP_NAME = "Structural Biology Platform Bundle"
+SBP_SHORT_NAME = "SBP"
+
+def _delete_legacy_sbp_group() -> None:
+    bind = op.get_bind()
+
+    for table in ("grouprolelink", "groupmembershiphistory", "groupmembership"):
+        bind.execute(
+            sa.text(f"DELETE FROM {table} WHERE group_id = :group_id"),
+            {"group_id": OLD_SBP_GROUP_ID},
+        )
+
+    bind.execute(
+        sa.text("DELETE FROM biocommonsgroup WHERE group_id = :group_id"),
+        {"group_id": OLD_SBP_GROUP_ID},
+    )
+
+
+def _upsert_sbp_workflow_execution_group() -> None:
+    bind = op.get_bind()
+    dialect = bind.dialect.name
+
+    if dialect == "postgresql":
+        bind.execute(
+            sa.text(
+                """
+                INSERT INTO biocommonsgroup (group_id, name, short_name, is_deleted)
+                VALUES (:group_id, :name, :short_name, FALSE)
+                    ON CONFLICT (group_id) DO UPDATE
+                                                  SET name = EXCLUDED.name,
+                                                  short_name = EXCLUDED.short_name,
+                                                  is_deleted = FALSE
+                """
+            ),
+            {
+                "group_id": SBP_GROUP_ID,
+                "name": SBP_NAME,
+                "short_name": SBP_SHORT_NAME,
+            },
+        )
+        return
+
+    existing = bind.execute(
+        sa.text("SELECT group_id FROM biocommonsgroup WHERE group_id = :group_id"),
+        {"group_id": SBP_GROUP_ID},
+    ).fetchone()
+
+    if existing is None:
+        bind.execute(
+            sa.text(
+                """
+                INSERT INTO biocommonsgroup (group_id, name, short_name, is_deleted)
+                VALUES (:group_id, :name, :short_name, FALSE)
+                """
+            ),
+            {
+                "group_id": SBP_GROUP_ID,
+                "name": SBP_NAME,
+                "short_name": SBP_SHORT_NAME,
+            },
+        )
+    else:
+        bind.execute(
+            sa.text(
+                """
+                UPDATE biocommonsgroup
+                SET name = :name,
+                    short_name = :short_name,
+                    is_deleted = FALSE
+                WHERE group_id = :group_id
+                """
+            ),
+            {
+                "group_id": SBP_GROUP_ID,
+                "name": SBP_NAME,
+                "short_name": SBP_SHORT_NAME,
+            },
+        )
+
+def upgrade() -> None:
+    _delete_legacy_sbp_group()
+    _upsert_sbp_workflow_execution_group()
+
+
+def downgrade() -> None:
+    pass

--- a/tests/migrations/test_migrations.py
+++ b/tests/migrations/test_migrations.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 from alembic import command
 from alembic.config import Config
+from sqlalchemy import text
 from sqlmodel import Session, create_engine
 
 from db.models import BiocommonsGroup
@@ -25,6 +26,83 @@ def test_sbp_group_migration_creates_expected_group(tmp_path, mocker):
     try:
         with Session(engine) as session:
             group = session.get(BiocommonsGroup, "biocommons/group/sbp_workflow_execution")
+            assert group is not None
+            assert group.group_id == "biocommons/group/sbp_workflow_execution"
+            assert group.name == "Structural Biology Platform Bundle"
+            assert group.short_name == "SBP"
+            assert group.is_deleted is False
+    finally:
+        engine.dispose()
+
+
+def test_sbp_cleanup_migration_removes_legacy_group_and_recreates_current_group(tmp_path, mocker):
+    db_path = tmp_path / "sbp_cleanup_migration.sqlite"
+    db_url = f"sqlite:///{db_path}"
+
+    mocker.patch("db.setup.get_db_config", return_value=(db_url, {"check_same_thread": False}))
+
+    repo_root = Path(__file__).resolve().parents[2]
+    alembic_config = Config(str(repo_root / "alembic.ini"))
+
+    command.upgrade(alembic_config, "274454823044")
+
+    engine = create_engine(
+        db_url,
+        connect_args={"check_same_thread": False},
+    )
+    try:
+        with Session(engine) as session:
+            session.exec(
+                text(
+                    "DELETE FROM biocommonsgroup "
+                    "WHERE group_id = 'biocommons/group/sbp_workflow_execution'"
+                )
+            )
+            session.exec(
+                text(
+                    """
+                    INSERT INTO biocommonsgroup (group_id, name, short_name, is_deleted)
+                    VALUES (
+                        'biocommons/group/sbp_bundle',
+                        'Structural Biology Platform Bundle',
+                        'SBP',
+                        FALSE
+                    )
+                    """
+                )
+            )
+            session.exec(
+                text(
+                    """
+                    INSERT INTO auth0role (id, name, description, is_deleted)
+                    VALUES ('legacy-sbp-admin-role', 'biocommons/role/sbp_bundle/admin', '', FALSE)
+                    """
+                )
+            )
+            session.exec(
+                text(
+                    """
+                    INSERT INTO grouprolelink (group_id, role_id, is_deleted)
+                    VALUES ('biocommons/group/sbp_bundle', 'legacy-sbp-admin-role', FALSE)
+                    """
+                )
+            )
+            session.commit()
+
+        command.upgrade(alembic_config, "4000ecb2796d")
+
+        with Session(engine) as session:
+            legacy_group = session.get(BiocommonsGroup, "biocommons/group/sbp_bundle")
+            group = session.get(BiocommonsGroup, "biocommons/group/sbp_workflow_execution")
+            legacy_links = session.exec(
+                text(
+                    "SELECT COUNT(*) FROM grouprolelink "
+                    "WHERE group_id = 'biocommons/group/sbp_bundle'"
+                )
+            ).one()[0]
+
+            assert legacy_group is None
+            assert legacy_links == 0
             assert group is not None
             assert group.group_id == "biocommons/group/sbp_workflow_execution"
             assert group.name == "Structural Biology Platform Bundle"


### PR DESCRIPTION
## Description

SBP bundle ID was changed from sbp_bundle -> sbp_workflow_execution, but this wasn't accounted for properly in migrations. Add a migration to clean up the incorrect entry in the database (by deleting all related entries) before creating the correct one.

The incorrect migration was only pushed to dev so should be safe to do.