### PR TITLE
fix: temporarily whitelist biocommons.org.au email for testing

### DIFF
--- a/services/institutions.py
+++ b/services/institutions.py
@@ -2,6 +2,9 @@ import httpx
 
 GALAXY_AU_VALIDATE_URL = "https://site.usegalaxy.org.au/institution/validate"
 
+# TODO: Remove this once Galaxy adds biocommons.org.au in their institions list
+ALWAYS_VALID_DOMAINS = {"biocommons.org.au"}
+
 
 async def is_australian_research_institution_email(email: str) -> bool:
     """Check email against Galaxy Australia's institution validation API.
@@ -9,6 +12,10 @@ async def is_australian_research_institution_email(email: str) -> bool:
     Returns False on any network or parse error so registration is never
     blocked by an upstream outage.
     """
+    domain = email.split("@")[-1].lower() if "@" in email else ""
+    if domain in ALWAYS_VALID_DOMAINS:
+        return True
+
     try:
         async with httpx.AsyncClient(timeout=5.0) as client:
             response = await client.get(GALAXY_AU_VALIDATE_URL, params={"email": email})


### PR DESCRIPTION
## Description

[AAI-815](https://biocloud.atlassian.net/browse/AAI-815): Temporary whitelist biocommons.org.au email domain for testing. The request to Galaxy is tracked here: https://github.com/usegalaxy-au/galaxy-media-site/issues/199#issuecomment-4487094913.

## Changes

- Whitelist `biocommons.org.au` when validating user email for accessing SBP bundle

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit / integration tests that prove my fix is effective or that my feature works
- [x] I have run all tests locally and they pass
- [ ] I have updated the documentation (if applicable)
- [ ] For any new secrets, I have updated the [shared spreadsheet](https://docs.google.com/spreadsheets/d/16lGloFh4VxMmu6cJdeFVLy2654hdq-ZeErhB8UifSfI/edit?usp=sharing) and the [GitHub Secrets](https://github.com/AustralianBioCommons/aai-backend/settings/secrets/actions).

## How to Test Manually (if necessary)

`uv run pytest`

[AAI-815]: https://biocloud.atlassian.net/browse/AAI-815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ