### PR TITLE
feat: add endpoint and email for deleting accounts with incorrect email (AAI-829)

### DIFF
--- a/biocommons/emails.py
+++ b/biocommons/emails.py
@@ -354,3 +354,27 @@ def compose_bundle_request_confirmation_email(
         portal_url=portal_url,
     )
     return subject, email_html
+
+
+def compose_incorrect_email_notification_email(
+        *,
+        first_name: str,
+        incorrect_email: str,
+        settings: Settings,
+):
+    subject = "Did you register for a BioCommons Access account?"
+    portal_url = settings.aai_portal_url
+    register_url = portal_url.rstrip("/") + "/register"
+    body_html = render_html_template(
+        "emails/incorrect_email.html",
+        first_name=first_name,
+        incorrect_email=incorrect_email,
+        register_url=register_url,
+    )
+    email_html = render_default_email_html(
+        title=subject,
+        preheader=subject,
+        body_html=body_html,
+        portal_url=portal_url,
+    )
+    return subject, email_html

--- a/biocommons/emails.py
+++ b/biocommons/emails.py
@@ -6,6 +6,7 @@ from auth0.client import Auth0Client
 from config import Settings, get_settings
 from db.models import BiocommonsGroup
 from dependencies.templates import TEMPLATES
+from schemas.biocommons import Auth0UserData
 
 logger = logging.getLogger("uvicorn.error")
 
@@ -59,6 +60,14 @@ def get_default_sender_email(settings: Settings | None = None) -> str:
     logger.info(f"Got default sender email: {email}")
     logger.info(f"Email settings: {settings.no_reply_email_sender=}")
     return str(email)
+
+
+def get_user_first_name(user: Auth0UserData, fallback: str):
+    return format_first_name(
+        full_name=user.name,
+        given_name=user.given_name,
+        fallback=fallback,
+    )
 
 
 def format_first_name(

--- a/biocommons/emails.py
+++ b/biocommons/emails.py
@@ -14,6 +14,7 @@ logger = logging.getLogger("uvicorn.error")
 _LOGO_URL = "https://images.squarespace-cdn.com/content/v1/5d3a4213cf4f5b00014ea1db/1689141619044-F67XDPQLP4PG6KY862VA/Australian-Biocommons-Logo-Horizontal-RGB.png"
 _ICON_MAIL = "https://cdn.auth0.com/website/emails/product/icon-mail.png"
 _P = "margin: 0 0 12px; font-size: 16px; line-height: 24px; color: #171717; text-align: left;"
+_P_CENTER = "margin: 0 0 12px; font-size: 16px; line-height: 24px; color: #171717; text-align: center;"
 _LI = "font-size: 16px; line-height: 24px; color: #171717;"
 _UL = "margin: 0 0 12px; padding-left: 24px; text-align: left;"
 _P_SIGN_OFF = "margin: 24px 0 12px; font-size: 16px; line-height: 24px; color: #171717; text-align: left;"
@@ -44,6 +45,7 @@ def render_html_template(template_name: str, **kwargs) -> str:
     template = TEMPLATES.get_template(name=template_name)
     style_defaults = {
         "p_style": _P,
+        "p_center_style": _P_CENTER,
         "a_style": _A,
         "p_signoff": _P_SIGN_OFF,
         "li_style": _LI,

--- a/biocommons/emails.py
+++ b/biocommons/emails.py
@@ -155,7 +155,7 @@ def compose_group_approval_email(
 ) -> tuple[str, str]:
     subject = f"{bundle_name} Service Bundle request"
     reason = request_reason.strip() if request_reason else "Not provided"
-    portal_url = settings.aai_portal_url or ""
+    portal_url = settings.aai_portal_url
     body_html = render_html_template(
         "emails/group_approval.html",
         admin_first_name=admin_first_name,
@@ -182,7 +182,7 @@ def compose_group_membership_approved_email(
     """
     Notify a user that their group/bundle access was approved.
     """
-    portal_url = settings.aai_portal_url or ""
+    portal_url = settings.aai_portal_url
     short_name = group_short_name or group_name
     short_suffix = (
         f" ({short_name})" if short_name and short_name != group_name else ""
@@ -213,7 +213,7 @@ def compose_email_change_notification(
     """
     Notify a user that their email address was updated.
     """
-    portal_url = settings.aai_portal_url or ""
+    portal_url = settings.aai_portal_url
     subject = "Your Biocommons Access email address was updated"
     body_html = render_html_template(
         "emails/email_changed.html",
@@ -239,7 +239,7 @@ def compose_username_change_notification(
     """
     Notify a user that their username was updated.
     """
-    portal_url = settings.aai_portal_url or ""
+    portal_url = settings.aai_portal_url
     subject = "Your Biocommons Access username was updated"
     body_html = render_html_template(
         "emails/username_changed.html",
@@ -311,7 +311,7 @@ def compose_group_membership_rejected_email(
     Notify a user that their group/bundle access request was rejected.
     For the TSI bundle, includes detailed information about open-access alternatives.
     """
-    portal_url = settings.aai_portal_url or ""
+    portal_url = settings.aai_portal_url
     subject = "Threatened Species Initiative service bundle request"
     body_html = render_html_template(
         "emails/group_membership_rejected.html",
@@ -338,7 +338,7 @@ def compose_bundle_request_confirmation_email(
     Confirmation email sent to a user after they request access to a bundle/group.
     Informs them their request was received and explains next steps.
     """
-    portal_url = settings.aai_portal_url or ""
+    portal_url = settings.aai_portal_url
     reason = request_reason.strip() if request_reason else "Not provided"
     subject = f"Your {bundle_name} Service Bundle request has been received"
     body_html = render_html_template(

--- a/biocommons/emails.py
+++ b/biocommons/emails.py
@@ -6,12 +6,15 @@ from pydantic import EmailStr
 from auth0.client import Auth0Client
 from config import Settings, get_settings
 from db.models import BiocommonsGroup
+from dependencies.templates import TEMPLATES
 
 logger = logging.getLogger("uvicorn.error")
 
 _LOGO_URL = "https://images.squarespace-cdn.com/content/v1/5d3a4213cf4f5b00014ea1db/1689141619044-F67XDPQLP4PG6KY862VA/Australian-Biocommons-Logo-Horizontal-RGB.png"
 _ICON_MAIL = "https://cdn.auth0.com/website/emails/product/icon-mail.png"
 _P = "margin: 0 0 12px; font-size: 16px; line-height: 24px; color: #171717; text-align: left;"
+_LI = "font-size: 16px; line-height: 24px; color: #171717;"
+_UL = "margin: 0 0 12px; padding-left: 24px; text-align: left;"
 _P_SIGN_OFF = "margin: 24px 0 12px; font-size: 16px; line-height: 24px; color: #171717; text-align: left;"
 _A = "color: #171717; text-decoration: underline;"
 
@@ -71,6 +74,39 @@ def _wrap_email_html(
     </table>
   </body>
 </html>"""
+
+
+def render_default_email_html(
+    title: str,
+    preheader: str,
+    body_html: str,
+    portal_url: str,
+    icon_url: str = _ICON_MAIL,
+    logo_url: str = _LOGO_URL,
+) -> str:
+    email_template = TEMPLATES.get_template(name="emails/default_email.html")
+    return email_template.render(
+        title=title,
+        preheader=preheader,
+        body_html=body_html,
+        portal_url=portal_url,
+        icon_url=icon_url,
+        logo_url=logo_url,
+    )
+
+
+def render_html_template(template_name: str, **kwargs) -> str:
+    """Render an HTML template with default styles and provided kwargs."""
+    template = TEMPLATES.get_template(name=template_name)
+    style_defaults = {
+        "p_style": _P,
+        "a_style": _A,
+        "p_signoff": _P_SIGN_OFF,
+        "li_style": _LI,
+        "ul_style": _UL,
+    }
+    template_kwargs = {**style_defaults, **kwargs}
+    return template.render(**template_kwargs)
 
 
 def get_default_sender_email(settings: Settings | None = None) -> str:
@@ -165,7 +201,7 @@ def get_group_admin_contacts(
     return list(contacts.items())
 
 
-def compose_group_approval_email(
+def compose_group_approval_email_old(
     *,
     admin_first_name: str,
     bundle_name: str,
@@ -194,7 +230,36 @@ def compose_group_approval_email(
     return subject, _wrap_email_html(subject, subject, body_content, portal_url)
 
 
-def compose_group_membership_approved_email(
+def compose_group_approval_email(
+        *,
+        admin_first_name: str,
+        bundle_name: str,
+        requester_full_name: str,
+        requester_email: str,
+        request_reason: str | None,
+        settings: Settings,
+) -> tuple[str, str]:
+    subject = f"{bundle_name} Service Bundle request"
+    reason = request_reason.strip() if request_reason else "Not provided"
+    portal_url = settings.aai_portal_url or ""
+    body_html = render_html_template(
+        "emails/group_approval.html",
+        admin_first_name=admin_first_name,
+        bundle_name=bundle_name,
+        requester_full_name=requester_full_name,
+        requester_email=requester_email,
+        reason=reason,
+    )
+    email_html = render_default_email_html(
+        title=subject,
+        preheader=subject,
+        body_html=body_html,
+        portal_url=portal_url,
+    )
+    return subject, email_html
+
+
+def compose_group_membership_approved_email_old(
     group_name: str,
     group_short_name: str,
     first_name: str,
@@ -230,7 +295,39 @@ def compose_group_membership_approved_email(
     return subject, _wrap_email_html(subject, subject, body_content, portal_url)
 
 
-def compose_email_change_notification(
+def compose_group_membership_approved_email(
+        group_name: str,
+        group_short_name: str,
+        first_name: str,
+        settings: Settings,
+) -> tuple[str, str]:
+    """
+    Notify a user that their group/bundle access was approved.
+    """
+    portal_url = settings.aai_portal_url or ""
+    short_name = group_short_name or group_name
+    short_suffix = (
+        f" ({short_name})" if short_name and short_name != group_name else ""
+    )
+    subject = f"{group_name} Service Bundle access approved"
+    body_html = render_html_template(
+        "emails/group_approved.html",
+        group_name=group_name,
+        short_suffix=short_suffix,
+        short_name=short_name,
+        first_name=first_name,
+        portal_url=portal_url,
+    )
+    email_html = render_default_email_html(
+        title=subject,
+        preheader=subject,
+        body_html=body_html,
+        portal_url=portal_url,
+    )
+    return subject, email_html
+
+
+def compose_email_change_notification_old(
     old_email: str,
     new_email: str,
     settings: Settings,
@@ -254,7 +351,32 @@ def compose_email_change_notification(
     return subject, _wrap_email_html(subject, subject, body_content, portal_url)
 
 
-def compose_username_change_notification(
+def compose_email_change_notification(
+        old_email: str,
+        new_email: str,
+        settings: Settings,
+) -> tuple[str, str]:
+    """
+    Notify a user that their email address was updated.
+    """
+    portal_url = settings.aai_portal_url or ""
+    subject = "Your Biocommons Access email address was updated"
+    body_html = render_html_template(
+        "emails/email_changed.html",
+        old_email=old_email,
+        new_email=new_email,
+        portal_url=portal_url,
+    )
+    email_html = render_default_email_html(
+        title=subject,
+        preheader=subject,
+        body_html=body_html,
+        portal_url=portal_url,
+    )
+    return subject, email_html
+
+
+def compose_username_change_notification_old(
     old_username: str,
     new_username: str,
     settings: Settings,
@@ -278,7 +400,31 @@ def compose_username_change_notification(
     return subject, _wrap_email_html(subject, subject, body_content, portal_url)
 
 
-def compose_email_change_otp_email(
+def compose_username_change_notification(
+        old_username: str,
+        new_username: str,
+        settings: Settings,
+) -> tuple[str, str]:
+    """
+    Notify a user that their username was updated.
+    """
+    portal_url = settings.aai_portal_url or ""
+    subject = "Your Biocommons Access username was updated"
+    body_html = render_html_template(
+        "emails/username_changed.html",
+        old_username=old_username,
+        new_username=new_username,
+        portal_url=portal_url,
+    )
+    email_html = render_default_email_html(
+        title=subject,
+        preheader=subject,
+        body_html=body_html,
+        portal_url=portal_url,
+    )
+    return subject, email_html
+
+def compose_email_change_otp_email_old(
     code: str,
     target_email: str,
     expiration_minutes: int,
@@ -301,7 +447,31 @@ def compose_email_change_otp_email(
     return subject, _wrap_email_html(subject, subject, body_content, portal_url)
 
 
-def compose_welcome_email(
+def compose_email_change_otp_email(
+        code: str,
+        target_email: str,
+        expiration_minutes: int,
+        portal_url: str = "",
+) -> tuple[str, str]:
+    """
+    Email OTP for confirming an email address change.
+    """
+    subject = "Confirm your new BioCommons Access email address"
+    body_html = render_html_template(
+        "emails/email_change_otp.html",
+        code=code,
+        target_email=target_email,
+        expiration_minutes=expiration_minutes,
+    )
+    email_html = render_default_email_html(
+        title=subject,
+        preheader=subject,
+        body_html=body_html,
+        portal_url=portal_url,
+    )
+    return subject, email_html
+
+def compose_welcome_email_old(
     first_name: str,
     portal_url: str,
 ) -> tuple[str, str]:
@@ -332,8 +502,26 @@ def compose_welcome_email(
     """
     return subject, _wrap_email_html(subject, subject, body_content, portal_url)
 
+def compose_welcome_email(
+        first_name: str,
+        portal_url: str,
+) -> tuple[str, str]:
+    """
+    Welcome email sent to new users after email verification
+    and to users who have been successfully migrated.
+    """
+    subject = "Welcome to BioCommons Access"
+    body_html = render_html_template("emails/welcome_email.html", first_name=first_name, portal_url=portal_url)
+    email_html = render_default_email_html(
+        title=subject,
+        preheader=subject,
+        body_html=body_html,
+        portal_url=portal_url,
+    )
+    return subject, email_html
 
-def compose_group_membership_rejected_email(
+
+def compose_group_membership_rejected_email_old(
     *,
     group_name: str,
     username: str,
@@ -371,7 +559,33 @@ def compose_group_membership_rejected_email(
     return subject, _wrap_email_html(subject, subject, body_content, portal_url)
 
 
-def compose_bundle_request_confirmation_email(
+def compose_group_membership_rejected_email(
+        *,
+        group_name: str,
+        username: str,
+        settings: Settings,
+) -> tuple[str, str]:
+    """
+    Notify a user that their group/bundle access request was rejected.
+    For the TSI bundle, includes detailed information about open-access alternatives.
+    """
+    portal_url = settings.aai_portal_url or ""
+    subject = "Threatened Species Initiative service bundle request"
+    body_html = render_html_template(
+        "emails/group_membership_rejected.html",
+        group_name=group_name,
+        username=username,
+    )
+    email_html = render_default_email_html(
+        title=subject,
+        preheader=subject,
+        body_html=body_html,
+        portal_url=portal_url,
+    )
+    return subject, email_html
+
+
+def compose_bundle_request_confirmation_email_old(
     *,
     first_name: str,
     bundle_name: str,
@@ -397,3 +611,32 @@ def compose_bundle_request_confirmation_email(
         <p style="{_P}">BioCommons Access team</p>
     """
     return subject, _wrap_email_html(subject, subject, body_content, portal_url)
+
+
+def compose_bundle_request_confirmation_email(
+        *,
+        first_name: str,
+        bundle_name: str,
+        request_reason: str | None,
+        settings: Settings,
+) -> tuple[str, str]:
+    """
+    Confirmation email sent to a user after they request access to a bundle/group.
+    Informs them their request was received and explains next steps.
+    """
+    portal_url = settings.aai_portal_url or ""
+    reason = request_reason.strip() if request_reason else "Not provided"
+    subject = f"Your {bundle_name} Service Bundle request has been received"
+    body_html = render_html_template(
+        "emails/bundle_request_confirmation.html",
+        first_name=first_name,
+        bundle_name=bundle_name,
+        reason=reason,
+    )
+    email_html = render_default_email_html(
+        title=subject,
+        preheader=subject,
+        body_html=body_html,
+        portal_url=portal_url,
+    )
+    return subject, email_html

--- a/biocommons/emails.py
+++ b/biocommons/emails.py
@@ -166,7 +166,6 @@ def compose_group_approval_email(
 ) -> tuple[str, str]:
     subject = f"{bundle_name} Service Bundle request"
     reason = request_reason.strip() if request_reason else "Not provided"
-    portal_url = settings.aai_portal_url
     body_html = render_html_template(
         "emails/group_approval.html",
         admin_first_name=admin_first_name,
@@ -179,7 +178,7 @@ def compose_group_approval_email(
         title=subject,
         preheader=subject,
         body_html=body_html,
-        portal_url=portal_url,
+        portal_url=settings.aai_portal_url,
     )
     return subject, email_html
 
@@ -193,7 +192,6 @@ def compose_group_membership_approved_email(
     """
     Notify a user that their group/bundle access was approved.
     """
-    portal_url = settings.aai_portal_url
     short_name = group_short_name or group_name
     short_suffix = (
         f" ({short_name})" if short_name and short_name != group_name else ""
@@ -205,13 +203,13 @@ def compose_group_membership_approved_email(
         short_suffix=short_suffix,
         short_name=short_name,
         first_name=first_name,
-        portal_url=portal_url,
+        portal_url=settings.aai_portal_url,
     )
     email_html = render_default_email_html(
         title=subject,
         preheader=subject,
         body_html=body_html,
-        portal_url=portal_url,
+        portal_url=settings.aai_portal_url,
     )
     return subject, email_html
 
@@ -224,19 +222,18 @@ def compose_email_change_notification(
     """
     Notify a user that their email address was updated.
     """
-    portal_url = settings.aai_portal_url
     subject = "Your Biocommons Access email address was updated"
     body_html = render_html_template(
         "emails/email_changed.html",
         old_email=old_email,
         new_email=new_email,
-        portal_url=portal_url,
+        portal_url=settings.aai_portal_url,
     )
     email_html = render_default_email_html(
         title=subject,
         preheader=subject,
         body_html=body_html,
-        portal_url=portal_url,
+        portal_url=settings.aai_portal_url,
     )
     return subject, email_html
 
@@ -250,19 +247,18 @@ def compose_username_change_notification(
     """
     Notify a user that their username was updated.
     """
-    portal_url = settings.aai_portal_url
     subject = "Your Biocommons Access username was updated"
     body_html = render_html_template(
         "emails/username_changed.html",
         old_username=old_username,
         new_username=new_username,
-        portal_url=portal_url,
+        portal_url=settings.aai_portal_url,
     )
     email_html = render_default_email_html(
         title=subject,
         preheader=subject,
         body_html=body_html,
-        portal_url=portal_url,
+        portal_url=settings.aai_portal_url,
     )
     return subject, email_html
 
@@ -322,7 +318,6 @@ def compose_group_membership_rejected_email(
     Notify a user that their group/bundle access request was rejected.
     For the TSI bundle, includes detailed information about open-access alternatives.
     """
-    portal_url = settings.aai_portal_url
     subject = "Threatened Species Initiative service bundle request"
     body_html = render_html_template(
         "emails/group_membership_rejected.html",
@@ -333,7 +328,7 @@ def compose_group_membership_rejected_email(
         title=subject,
         preheader=subject,
         body_html=body_html,
-        portal_url=portal_url,
+        portal_url=settings.aai_portal_url,
     )
     return subject, email_html
 
@@ -349,7 +344,6 @@ def compose_bundle_request_confirmation_email(
     Confirmation email sent to a user after they request access to a bundle/group.
     Informs them their request was received and explains next steps.
     """
-    portal_url = settings.aai_portal_url
     reason = request_reason.strip() if request_reason else "Not provided"
     subject = f"Your {bundle_name} Service Bundle request has been received"
     body_html = render_html_template(
@@ -362,7 +356,7 @@ def compose_bundle_request_confirmation_email(
         title=subject,
         preheader=subject,
         body_html=body_html,
-        portal_url=portal_url,
+        portal_url=settings.aai_portal_url,
     )
     return subject, email_html
 

--- a/biocommons/emails.py
+++ b/biocommons/emails.py
@@ -1,4 +1,3 @@
-import html
 import logging
 
 from pydantic import EmailStr
@@ -10,6 +9,7 @@ from dependencies.templates import TEMPLATES
 
 logger = logging.getLogger("uvicorn.error")
 
+# Default styles to inject into templates
 _LOGO_URL = "https://images.squarespace-cdn.com/content/v1/5d3a4213cf4f5b00014ea1db/1689141619044-F67XDPQLP4PG6KY862VA/Australian-Biocommons-Logo-Horizontal-RGB.png"
 _ICON_MAIL = "https://cdn.auth0.com/website/emails/product/icon-mail.png"
 _P = "margin: 0 0 12px; font-size: 16px; line-height: 24px; color: #171717; text-align: left;"
@@ -17,63 +17,6 @@ _LI = "font-size: 16px; line-height: 24px; color: #171717;"
 _UL = "margin: 0 0 12px; padding-left: 24px; text-align: left;"
 _P_SIGN_OFF = "margin: 24px 0 12px; font-size: 16px; line-height: 24px; color: #171717; text-align: left;"
 _A = "color: #171717; text-decoration: underline;"
-
-
-def _wrap_email_html(
-    title: str,
-    preheader: str,
-    body_html: str,
-    portal_url: str,
-    icon_url: str = _ICON_MAIL,
-) -> str:
-    safe_title = html.escape(title)
-    safe_preheader = html.escape(preheader)
-    safe_portal_url = html.escape(portal_url)
-    safe_logo_url = html.escape(_LOGO_URL)
-    safe_icon_url = html.escape(icon_url)
-    return f"""<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html dir="ltr" lang="en">
-  <head>
-    <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
-    <meta name="x-apple-disable-message-reformatting" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>{safe_title}</title>
-  </head>
-  <body style="margin: 0; padding: 0; background-color: #f5f5f5; font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;">
-    <div style="display: none; overflow: hidden; line-height: 1px; opacity: 0; max-height: 0; max-width: 0;">{safe_preheader}</div>
-    <table width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background-color: #f5f5f5; margin: 0; padding: 0">
-      <tr>
-        <td align="center" style="padding: 24px">
-          <table width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation" style="max-width: 660px; margin: 0 auto">
-            <tr>
-              <td style="background-color: #ffffff; border: 1px solid #e5e5e5; border-radius: 16px; padding: 32px; text-align: center;">
-                <a href="{safe_portal_url}" target="_blank" style="display: block; margin-bottom: 16px; text-decoration: none;">
-                  <img src="{safe_logo_url}" alt="BioCommons Logo" width="180" style="display: block; margin: 0 auto; width: 100%; max-width: 180px; height: auto; border: 0;" />
-                </a>
-                <hr style="border: none; border-top: 1px solid #e5e5e5; margin: 24px 0;" />
-                <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width: 64px; height: 64px; border-radius: 12px; background-color: #f5f5f5; margin: 0 auto;">
-                  <tr>
-                    <td align="center" valign="middle">
-                      <img src="{safe_icon_url}" width="24" height="24" alt="" style="display: block; border: 0; margin: 0 auto" />
-                    </td>
-                  </tr>
-                </table>
-                <h1 style="text-align: center; font-size: 24px; line-height: 32px; font-weight: 600; color: #171717; margin: 24px 0;">{safe_title}</h1>
-                <hr style="border: none; border-top: 1px solid #e5e5e5; margin: 24px 0;" />
-                {body_html}
-                <hr style="border: none; border-top: 1px solid #e5e5e5; margin: 24px 0;" />
-                <p style="font-size: 14px; line-height: 20px; color: #737373; margin: 0; text-align: center;">
-                  If you experience any issues, please refer to the
-                  <a href="https://biocommonsaccess.freshdesk.com/support/home" style="color: #171717; text-decoration: underline" target="_blank" rel="noopener noreferrer">FAQs or contact support</a>
-                </p>
-              </td>
-            </tr>
-          </table>
-        </td>
-      </tr>
-    </table>
-  </body>
-</html>"""
 
 
 def render_default_email_html(
@@ -201,35 +144,6 @@ def get_group_admin_contacts(
     return list(contacts.items())
 
 
-def compose_group_approval_email_old(
-    *,
-    admin_first_name: str,
-    bundle_name: str,
-    requester_full_name: str,
-    requester_email: str,
-    request_reason: str | None,
-    requester_user_id: str,
-    settings: Settings,
-) -> tuple[str, str]:
-    subject = f"{bundle_name} Service Bundle request"
-    reason = request_reason.strip() if request_reason else "Not provided"
-    safe_admin_first_name = html.escape(admin_first_name)
-    safe_bundle_name = html.escape(bundle_name)
-    safe_requester_full_name = html.escape(requester_full_name)
-    safe_requester_email = html.escape(requester_email)
-    safe_reason = html.escape(reason)
-    portal_url = settings.aai_portal_url or ""
-    body_content = f"""
-        <p style="{_P}">Dear {safe_admin_first_name},</p>
-        <p style="{_P}">You have received a new request for access to the {safe_bundle_name} Service Bundle.</p>
-        <p style="{_P}"><strong>Name:</strong> {safe_requester_full_name}<br/><strong>Email:</strong> {safe_requester_email}<br/><strong>Reason:</strong> {safe_reason}</p>
-        <p style="{_P}">Please log into the BioCommons Access bundle dashboard to review and approve or decline this request.</p>
-        <p style="{_P_SIGN_OFF}">Thank you,</p>
-        <p style="{_P}">BioCommons Access team</p>
-    """
-    return subject, _wrap_email_html(subject, subject, body_content, portal_url)
-
-
 def compose_group_approval_email(
         *,
         admin_first_name: str,
@@ -257,42 +171,6 @@ def compose_group_approval_email(
         portal_url=portal_url,
     )
     return subject, email_html
-
-
-def compose_group_membership_approved_email_old(
-    group_name: str,
-    group_short_name: str,
-    first_name: str,
-    settings: Settings,
-) -> tuple[str, str]:
-    """
-    Notify a user that their group/bundle access was approved.
-    """
-    portal_url = settings.aai_portal_url or ""
-    short_name = group_short_name or group_name
-    safe_group_name = html.escape(group_name or "")
-    safe_short_name = html.escape(short_name or "")
-    safe_first_name = html.escape(first_name or "")
-    safe_portal_url = html.escape(portal_url)
-    short_suffix = (
-        f" ({safe_short_name})" if safe_short_name and safe_short_name != safe_group_name else ""
-    )
-    subject = f"{safe_group_name} Service Bundle access approved"
-    body_content = f"""
-        <p style="{_P}">Dear {safe_first_name},</p>
-        <p style="{_P}">Your request to join the {safe_group_name}{short_suffix} service bundle has been approved.</p>
-        <p style="{_P}">If you are logged into either of the BioPlatforms Data Portal or Galaxy Australia, please log out and log back in again to ensure your access rights are updated.</p>
-        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="margin: 24px auto;">
-          <tr>
-            <td align="center">
-              <a href="{safe_portal_url}" target="_blank" rel="noopener noreferrer" style="display: inline-block; background-color: #171717; color: #ffffff; font-weight: 600; padding: 12px 18px; line-height: 20px; border-radius: 8px; text-decoration: none; font-size: 14px;">Go to BioCommons Access Portal</a>
-            </td>
-          </tr>
-        </table>
-        <p style="{_P_SIGN_OFF}">Thank you,</p>
-        <p style="{_P}">BioCommons Access team</p>
-    """
-    return subject, _wrap_email_html(subject, subject, body_content, portal_url)
 
 
 def compose_group_membership_approved_email(
@@ -327,30 +205,6 @@ def compose_group_membership_approved_email(
     return subject, email_html
 
 
-def compose_email_change_notification_old(
-    old_email: str,
-    new_email: str,
-    settings: Settings,
-) -> tuple[str, str]:
-    """
-    Notify a user that their email address was updated.
-    """
-    portal_url = settings.aai_portal_url or ""
-    safe_portal_url = html.escape(portal_url)
-    safe_old_email = html.escape(old_email)
-    safe_new_email = html.escape(new_email)
-    subject = "Your Biocommons Access email address was updated"
-    body_content = f"""
-        <p style="{_P}">Hello,</p>
-        <p style="{_P}">The email address on your Biocommons Access account was updated.</p>
-        <p style="{_P}"><strong>Old email:</strong> {safe_old_email}<br/><strong>New email:</strong> {safe_new_email}</p>
-        <p style="{_P}">If you did not expect this change, please visit the <a href="{safe_portal_url}" style="{_A}" target="_blank" rel="noopener noreferrer">BioCommons Access Portal</a> or contact support.</p>
-        <p style="{_P_SIGN_OFF}">Thank you,</p>
-        <p style="{_P}">BioCommons Access team</p>
-    """
-    return subject, _wrap_email_html(subject, subject, body_content, portal_url)
-
-
 def compose_email_change_notification(
         old_email: str,
         new_email: str,
@@ -375,29 +229,6 @@ def compose_email_change_notification(
     )
     return subject, email_html
 
-
-def compose_username_change_notification_old(
-    old_username: str,
-    new_username: str,
-    settings: Settings,
-) -> tuple[str, str]:
-    """
-    Notify a user that their username was updated.
-    """
-    portal_url = settings.aai_portal_url or ""
-    safe_portal_url = html.escape(portal_url)
-    safe_old_username = html.escape(old_username)
-    safe_new_username = html.escape(new_username)
-    subject = "Your Biocommons Access username was updated"
-    body_content = f"""
-        <p style="{_P}">Hello,</p>
-        <p style="{_P}">The username on your Biocommons Access account was updated by your service administrator.</p>
-        <p style="{_P}"><strong>Old username:</strong> {safe_old_username}<br/><strong>New username:</strong> {safe_new_username}</p>
-        <p style="{_P}">If you did not expect this change, please visit the <a href="{safe_portal_url}" style="{_A}" target="_blank" rel="noopener noreferrer">BioCommons Access Portal</a> or contact support.</p>
-        <p style="{_P_SIGN_OFF}">Thank you,</p>
-        <p style="{_P}">BioCommons Access team</p>
-    """
-    return subject, _wrap_email_html(subject, subject, body_content, portal_url)
 
 
 def compose_username_change_notification(
@@ -424,28 +255,6 @@ def compose_username_change_notification(
     )
     return subject, email_html
 
-def compose_email_change_otp_email_old(
-    code: str,
-    target_email: str,
-    expiration_minutes: int,
-    portal_url: str = "",
-) -> tuple[str, str]:
-    """
-    Email OTP for confirming an email address change.
-    """
-    safe_target_email = html.escape(target_email)
-    safe_code = html.escape(code)
-    subject = "Confirm your new BioCommons Access email address"
-    body_content = f"""
-        <p style="{_P}">Hello,</p>
-        <p style="{_P}">We received a request to change the email address of your BioCommons Access account to {safe_target_email}.</p>
-        <p style="{_P}">Your verification code is <strong>{safe_code}</strong>.</p>
-        <p style="{_P}">This code is valid for {expiration_minutes} minutes.</p>
-        <p style="{_P_SIGN_OFF}">Thank you,</p>
-        <p style="{_P}">BioCommons Access team</p>
-    """
-    return subject, _wrap_email_html(subject, subject, body_content, portal_url)
-
 
 def compose_email_change_otp_email(
         code: str,
@@ -471,36 +280,6 @@ def compose_email_change_otp_email(
     )
     return subject, email_html
 
-def compose_welcome_email_old(
-    first_name: str,
-    portal_url: str,
-) -> tuple[str, str]:
-    """
-    Welcome email sent to new users after email verification
-    and to users who have been successfully migrated.
-    """
-    safe_first_name = html.escape(first_name)
-    safe_portal_url = html.escape(portal_url)
-    subject = "Welcome to BioCommons Access"
-    body_content = f"""
-        <p style="{_P}">Dear {safe_first_name},</p>
-        <p style="{_P}">Welcome to your new BioCommons Access account!</p>
-        <p style="{_P}"><strong><a href="https://www.biocommons.org.au/access" target="_blank" rel="noopener noreferrer" style="{_A}">BioCommons Access</a> is your key to unlocking analysis services and research data across the Australian BioCommons ecosystem. A single log in offers convenient and secure access to a growing number of services.</strong></p>
-        <p style="{_P}">Consider bookmarking <a href="{safe_portal_url}" target="_blank" rel="noopener noreferrer" style="{_A}">{safe_portal_url}</a> for future logins. Use the BioCommons Access portal to access connected services, update your profile and apply for Service Bundles.</p>
-        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="margin: 24px auto;">
-          <tr>
-            <td align="center">
-              <a href="{safe_portal_url}" target="_blank" rel="noopener noreferrer" style="display: inline-block; background-color: #171717; color: #ffffff; font-weight: 600; padding: 12px 18px; line-height: 20px; border-radius: 8px; text-decoration: none; font-size: 14px;">BioCommons Access Login</a>
-            </td>
-          </tr>
-        </table>
-        <p style="{_P}">The BioCommons Access portal contains links to services including Galaxy Australia and the Bioplatforms Australia Data Portal. You can also access these services directly with your BioCommons Access credentials.</p>
-        <p style="{_P}">You can <a href="https://biocommonsaccess.freshdesk.com/support/home" target="_blank" rel="noopener noreferrer" style="{_A}">access support for your BioCommons Access account</a>, or find help related to <a href="https://www.biocommons.org.au/access-existing-users" target="_blank" rel="noopener noreferrer" style="{_A}">migrating existing Galaxy Australia or Bioplatforms Australia Data Portal accounts</a>.</p>
-        <p style="{_P}">To hear when future services come online, as well as relevant training and other ways to connect, <a href="https://www.biocommons.org.au/subscribe" target="_blank" rel="noopener noreferrer" style="{_A}">subscribe to the Australian BioCommons monthly newsletter</a>.</p>
-        <p style="{_P_SIGN_OFF}">Thank you,</p>
-        <p style="{_P}">The Australian BioCommons<br/><a href="https://www.biocommons.org.au" target="_blank" rel="noopener noreferrer" style="{_A}">www.biocommons.org.au</a></p>
-    """
-    return subject, _wrap_email_html(subject, subject, body_content, portal_url)
 
 def compose_welcome_email(
         first_name: str,
@@ -520,43 +299,6 @@ def compose_welcome_email(
     )
     return subject, email_html
 
-
-def compose_group_membership_rejected_email_old(
-    *,
-    group_name: str,
-    username: str,
-    settings: Settings,
-) -> tuple[str, str]:
-    """
-    Notify a user that their group/bundle access request was rejected.
-    For the TSI bundle, includes detailed information about open-access alternatives.
-    """
-    portal_url = settings.aai_portal_url or ""
-    safe_group_name = html.escape(group_name or "")
-    safe_username = html.escape(username or "")
-    subject = "Threatened Species Initiative service bundle request"
-
-    _TSI_LINK = f'<a href="https://bioplatforms.com/project/threatened-species/" target="_blank" rel="noopener noreferrer" style="{_A}">Threatened Species Initiative</a>'
-    body_content = f"""
-        <p style="{_P}">Dear {safe_username},</p>
-        <p style="{_P}">Thank you for your interest in the {safe_group_name} Bundle.</p>
-        <p style="{_P}">The TSI Bundle available on BioCommons Access is only for members of the {_TSI_LINK} consortium.</p>
-        <p style="{_P}">Members are collaborators who have projects supported through our request for partnership rounds. They can access datasets that are under embargo for the first 12 months following their generation.</p>
-        <p style="{_P}">The {_TSI_LINK} is generating genomic resources that are made openly accessible to the community through the Bioplatforms Australia data portal. To obtain access to the open access genomics datasets, you only need to register for an account and you do not need to apply to the TSI Bundle. This is also the case for datasets of all other initiatives presented on the <a href="https://data.bioplatforms.com/all_projects" target="_blank" rel="noopener noreferrer" style="{_A}">Bioplatforms Data Portal</a>.</p>
-        <p style="{_P}">Similarly, various tools - including <a href="https://www.biocommons.org.au/fgenesh-plus-plus" target="_blank" rel="noopener noreferrer" style="{_A}">FGenesh++</a> and AlphaFold, can be directly accessed through <a href="https://site.usegalaxy.org.au/" target="_blank" rel="noopener noreferrer" style="{_A}">Galaxy Australia</a> without the need of the TSI Bundle:</p>
-        <ul style="margin: 0 0 12px; padding-left: 24px; text-align: left;">
-          <li style="font-size: 16px; line-height: 24px; color: #171717;"><a href="https://site.usegalaxy.org.au/request/access" target="_blank" rel="noopener noreferrer" style="{_A}">Request access to specialist tools</a></li>
-        </ul>
-        <p style="{_P}">Please do not hesitate to reach out to us for any non registration related issues:</p>
-        <ul style="margin: 0 0 12px; padding-left: 24px; text-align: left;">
-          <li style="font-size: 16px; line-height: 24px; color: #171717;">Bioplatforms Australia Data Portal — <a href="mailto:help@bioplatforms.com" style="{_A}">help@bioplatforms.com</a></li>
-          <li style="font-size: 16px; line-height: 24px; color: #171717;">Galaxy Australia — <a href="https://site.usegalaxy.org.au/request/" target="_blank" rel="noopener noreferrer" style="{_A}">Galaxy Australia - Help and support</a></li>
-          <li style="font-size: 16px; line-height: 24px; color: #171717;">TSI specific enquiries — <a href="mailto:smazard@bioplatforms.com" style="{_A}">smazard@bioplatforms.com</a></li>
-        </ul>
-        <p style="{_P_SIGN_OFF}">Thank you,</p>
-        <p style="{_P}">BioCommons Access Team</p>
-    """
-    return subject, _wrap_email_html(subject, subject, body_content, portal_url)
 
 
 def compose_group_membership_rejected_email(
@@ -583,34 +325,6 @@ def compose_group_membership_rejected_email(
         portal_url=portal_url,
     )
     return subject, email_html
-
-
-def compose_bundle_request_confirmation_email_old(
-    *,
-    first_name: str,
-    bundle_name: str,
-    request_reason: str | None,
-    settings: Settings,
-) -> tuple[str, str]:
-    """
-    Confirmation email sent to a user after they request access to a bundle/group.
-    Informs them their request was received and explains next steps.
-    """
-    portal_url = settings.aai_portal_url or ""
-    reason = request_reason.strip() if request_reason else "Not provided"
-    safe_first_name = html.escape(first_name)
-    safe_bundle_name = html.escape(bundle_name)
-    safe_reason = html.escape(reason)
-    subject = f"Your {bundle_name} Service Bundle request has been received"
-    body_content = f"""
-        <p style="{_P}">Dear {safe_first_name},</p>
-        <p style="{_P}">Thank you for submitting a request to join the <strong>{safe_bundle_name}</strong> Service Bundle. Your request has been received and is currently under review.</p>
-        <p style="{_P}"><strong>Bundle requested:</strong> {safe_bundle_name}<br/><strong>Reason provided:</strong> {safe_reason}</p>
-        <p style="{_P}">A bundle administrator will review your request. If your request is approved, you will receive a confirmation email with further details.</p>
-        <p style="{_P_SIGN_OFF}">Thank you,</p>
-        <p style="{_P}">BioCommons Access team</p>
-    """
-    return subject, _wrap_email_html(subject, subject, body_content, portal_url)
 
 
 def compose_bundle_request_confirmation_email(

--- a/config.py
+++ b/config.py
@@ -25,7 +25,7 @@ class Settings(BaseSettings):
     #   to be available before the app starts
     cors_allowed_origins: str
     # AAI Portal URL for admin links in emails
-    aai_portal_url: Optional[str] = None
+    aai_portal_url: str = ""
     # Sender override for emails that should come from a no-reply address
     no_reply_email_sender: EmailStr
     # SES resource ARN for sending emails
@@ -52,11 +52,11 @@ class Settings(BaseSettings):
             return None
         return value.rstrip("/")
 
-    @field_validator("aai_portal_url", mode="after")
+    @field_validator("aai_portal_url", mode="before")
     @classmethod
-    def strip_aai_portal_trailing_slash(cls, value: str | None) -> str | None:
+    def strip_aai_portal_trailing_slash(cls, value: str | None) -> str:
         if value is None:
-            return None
+            return ""
         return value.rstrip("/")
 
     @model_validator(mode="after")

--- a/dependencies/templates.py
+++ b/dependencies/templates.py
@@ -1,0 +1,12 @@
+from fastapi.templating import Jinja2Templates
+from jinja2 import StrictUndefined
+
+TEMPLATES = Jinja2Templates(
+    directory="templates",
+    autoescape=True,
+    undefined=StrictUndefined,
+)
+
+
+def get_templates():
+    return TEMPLATES

--- a/routers/admin.py
+++ b/routers/admin.py
@@ -1122,7 +1122,7 @@ class AdminInvalidEmailDeleteData(BaseModel):
     """
     Data model for the payload of the /users/{user_id}/delete_invalid_email endpoint.
     """
-    reason: str
+    reason: str | None = None
     correct_email: EmailStr
 
 
@@ -1139,7 +1139,7 @@ def delete_user_invalid_email(
     logger.info(f"Triggering user deletion for {user_id} by {current_admin.id}")
     db_user.soft_delete(
         deleted_by=current_admin,
-        reason=delete_data.reason,
+        reason=delete_data.reason or "Invalid email address",
         session=db_session,
         auth0_client=client,
     )

--- a/routers/admin.py
+++ b/routers/admin.py
@@ -8,7 +8,14 @@ from typing import Annotated, Any
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Response
 from fastapi.params import Query
 from httpx import HTTPStatusError
-from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    EmailStr,
+    Field,
+    ValidationError,
+    field_validator,
+)
 from sqlalchemy import exists, func, or_
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import selectinload
@@ -32,8 +39,10 @@ from biocommons.emails import (
     compose_email_change_notification,
     compose_group_membership_approved_email,
     compose_group_membership_rejected_email,
+    compose_incorrect_email_notification_email,
     compose_username_change_notification,
     format_first_name,
+    get_user_first_name,
 )
 from config import Settings, get_settings
 from db.models import (
@@ -1109,6 +1118,48 @@ def delete_user(user_id: Annotated[str, UserIdParam],
     )
     return {"message": f"User {user_id} deleted successfully."}
 
+class AdminInvalidEmailDeleteData:
+    """
+    Data model for the payload of the /users/{user_id}/delete_invalid_email endpoint.
+    """
+    reason: str
+    correct_email: EmailStr
+
+
+@router.post("/users/{user_id}/delete_invalid_email",
+             dependencies=[Depends(require_platform_admin_permission_for_user)])
+def delete_user_invalid_email(
+        user_id: Annotated[str, UserIdParam],
+        delete_data: AdminInvalidEmailDeleteData,
+        client: Annotated[Auth0Client, Depends(get_auth0_client)],
+        current_admin: Annotated[BiocommonsUser, Depends(get_db_user)],
+        db_session: Annotated[Session, Depends(get_db_session)],
+        settings: Annotated[Settings, Depends(get_settings)],):
+    db_user = BiocommonsUser.get_by_id_or_404(user_id, db_session)
+    logger.info(f"Triggering user deletion for {user_id} by {current_admin.id}")
+    db_user.soft_delete(
+        deleted_by=current_admin,
+        reason=delete_data.reason,
+        session=db_session,
+        auth0_client=client,
+    )
+    logger.info(f"User {user_id} marked as deleted in database")
+    if delete_data.correct_email:
+        logger.info("Sending email to notify user of incorrect email")
+        auth0_user = client.get_user(user_id)
+        first_name = get_user_first_name(auth0_user, fallback="there")
+        subject, html = compose_incorrect_email_notification_email(
+            first_name=first_name,
+            incorrect_email=auth0_user.email,
+            settings=settings,
+        )
+        enqueue_email(
+            session=db_session,
+            to_address=delete_data.correct_email,
+            subject=subject,
+            body_html=html,
+            settings=settings,
+        )
 
 @router.post(
     "/users/{user_id}/verification-email/resend",

--- a/routers/admin.py
+++ b/routers/admin.py
@@ -1160,6 +1160,8 @@ def delete_user_invalid_email(
             body_html=html,
             settings=settings,
         )
+        db_session.commit()
+    return {"message": f"User {user_id} deleted successfully."}
 
 @router.post(
     "/users/{user_id}/verification-email/resend",

--- a/routers/admin.py
+++ b/routers/admin.py
@@ -41,7 +41,6 @@ from biocommons.emails import (
     compose_group_membership_rejected_email,
     compose_incorrect_email_notification_email,
     compose_username_change_notification,
-    format_first_name,
     get_user_first_name,
 )
 from config import Settings, get_settings
@@ -1270,11 +1269,7 @@ def approve_group_membership(user_id: Annotated[str, UserIdParam],
         first_name = "there"
         try:
             auth0_user = client.get_user(membership.user.id)
-            first_name = format_first_name(
-                full_name=auth0_user.name,
-                given_name=auth0_user.given_name,
-                fallback="there",
-            )
+            first_name = get_user_first_name(auth0_user, fallback="there")
         except Exception:
             pass
         subject, body_html = compose_group_membership_approved_email(

--- a/routers/admin.py
+++ b/routers/admin.py
@@ -1117,7 +1117,8 @@ def delete_user(user_id: Annotated[str, UserIdParam],
     )
     return {"message": f"User {user_id} deleted successfully."}
 
-class AdminInvalidEmailDeleteData:
+
+class AdminInvalidEmailDeleteData(BaseModel):
     """
     Data model for the payload of the /users/{user_id}/delete_invalid_email endpoint.
     """

--- a/routers/admin.py
+++ b/routers/admin.py
@@ -1136,16 +1136,8 @@ def delete_user_invalid_email(
         db_session: Annotated[Session, Depends(get_db_session)],
         settings: Annotated[Settings, Depends(get_settings)],):
     db_user = BiocommonsUser.get_by_id_or_404(user_id, db_session)
-    logger.info(f"Triggering user deletion for {user_id} by {current_admin.id}")
-    db_user.soft_delete(
-        deleted_by=current_admin,
-        reason=delete_data.reason or "Invalid email address",
-        session=db_session,
-        auth0_client=client,
-    )
-    logger.info(f"User {user_id} marked as deleted in database")
-    if delete_data.correct_email:
-        logger.info("Sending email to notify user of incorrect email")
+    try:
+        logger.info("Queueing email to notify user of incorrect email")
         auth0_user = client.get_user(user_id)
         first_name = get_user_first_name(auth0_user, fallback="there")
         subject, html = compose_incorrect_email_notification_email(
@@ -1160,7 +1152,22 @@ def delete_user_invalid_email(
             body_html=html,
             settings=settings,
         )
-        db_session.commit()
+    except Exception as exc:
+        db_session.rollback()
+        logger.exception(f"Failed to queue incorrect email notification for user {user_id}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to queue incorrect email notification.",
+        ) from exc
+
+    logger.info(f"Triggering user deletion for {user_id} by {current_admin.id}")
+    db_user.soft_delete(
+        deleted_by=current_admin,
+        reason=delete_data.reason or "Invalid email address",
+        session=db_session,
+        auth0_client=client,
+    )
+    logger.info(f"User {user_id} marked as deleted in database")
     return {"message": f"User {user_id} deleted successfully."}
 
 @router.post(

--- a/routers/biocommons_register.py
+++ b/routers/biocommons_register.py
@@ -130,7 +130,6 @@ def _notify_bundle_group_admins(
             requester_full_name=requester_full_name,
             requester_email=requester_email,
             request_reason=membership.request_reason,
-            requester_user_id=membership.user_id,
             settings=settings,
         )
         enqueue_email(

--- a/routers/user.py
+++ b/routers/user.py
@@ -455,7 +455,6 @@ def send_group_request_emails(user: SessionUser,
             requester_full_name=requester_full_name,
             requester_email=requester_email or membership.user.email,
             request_reason=membership.request_reason,
-            requester_user_id=membership.user_id,
             settings=settings,
         )
         enqueue_email(

--- a/templates/emails/bundle_request_confirmation.html
+++ b/templates/emails/bundle_request_confirmation.html
@@ -1,0 +1,6 @@
+<p style="{{ p_style }}">Dear {{ first_name }},</p>
+<p style="{{ p_style }}">Thank you for submitting a request to join the <strong>{{ bundle_name }}</strong> Service Bundle. Your request has been received and is currently under review.</p>
+<p style="{{ p_style }}"><strong>Bundle requested:</strong> {{ bundle_name }}<br/><strong>Reason provided:</strong> {{ reason }}</p>
+<p style="{{ p_style }}">A bundle administrator will review your request. If your request is approved, you will receive a confirmation email with further details.</p>
+<p style="{{ p_signoff }}">Thank you,</p>
+<p style="{{ p_style }}">BioCommons Access team</p>

--- a/templates/emails/default_email.html
+++ b/templates/emails/default_email.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html dir="ltr" lang="en">
+  <head>
+    <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
+    <meta name="x-apple-disable-message-reformatting" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>{{ title }}</title>
+  </head>
+  <body style="margin: 0; padding: 0; background-color: #f5f5f5; font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;">
+    <div style="display: none; overflow: hidden; line-height: 1px; opacity: 0; max-height: 0; max-width: 0;">{{ preheader }}</div>
+    <table width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background-color: #f5f5f5; margin: 0; padding: 0">
+      <tr>
+        <td align="center" style="padding: 24px">
+          <table width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation" style="max-width: 660px; margin: 0 auto">
+            <tr>
+              <td style="background-color: #ffffff; border: 1px solid #e5e5e5; border-radius: 16px; padding: 32px; text-align: center;">
+                <a href="{{ portal_url }}" target="_blank" style="display: block; margin-bottom: 16px; text-decoration: none;">
+                  <img src="{{ logo_url }}" alt="BioCommons Logo" width="180" style="display: block; margin: 0 auto; width: 100%; max-width: 180px; height: auto; border: 0;" />
+                </a>
+                <hr style="border: none; border-top: 1px solid #e5e5e5; margin: 24px 0;" />
+                <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width: 64px; height: 64px; border-radius: 12px; background-color: #f5f5f5; margin: 0 auto;">
+                  <tr>
+                    <td align="center" valign="middle">
+                      <img src="{{ icon_url }}" width="24" height="24" alt="" style="display: block; border: 0; margin: 0 auto" />
+                    </td>
+                  </tr>
+                </table>
+                <h1 style="text-align: center; font-size: 24px; line-height: 32px; font-weight: 600; color: #171717; margin: 24px 0;">{{ title }}</h1>
+                <hr style="border: none; border-top: 1px solid #e5e5e5; margin: 24px 0;" />
+                    {{ body_html | safe }}
+                <hr style="border: none; border-top: 1px solid #e5e5e5; margin: 24px 0;" />
+                <p style="font-size: 14px; line-height: 20px; color: #737373; margin: 0; text-align: center;">
+                  If you experience any issues, please refer to the
+                  <a href="https://biocommonsaccess.freshdesk.com/support/home" style="color: #171717; text-decoration: underline" target="_blank" rel="noopener noreferrer">FAQs or contact support</a>
+                </p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/templates/emails/email_change_otp.html
+++ b/templates/emails/email_change_otp.html
@@ -1,0 +1,6 @@
+<p style="{{ p_style }}">Hello,</p>
+<p style="{{ p_style }}">We received a request to change the email address of your BioCommons Access account to {{ target_email }}.</p>
+<p style="{{ p_style }}">Your verification code is <strong>{{ code }}</strong>.</p>
+<p style="{{ p_style }}">This code is valid for {{ expiration_minutes }} minutes.</p>
+<p style="{{ p_signoff }}">Thank you,</p>
+<p style="{{ p_style }}">BioCommons Access team</p>

--- a/templates/emails/email_changed.html
+++ b/templates/emails/email_changed.html
@@ -1,0 +1,8 @@
+<p style="{{ p_style }}">Hello,</p>
+<p style="{{ p_style }}">The email address on your Biocommons Access account was updated.</p>
+<p style="{{ p_style }}">
+    <strong>Old email:</strong> {{ old_email }}<br/>
+    <strong>New email:</strong> {{ new_email }}</p>
+<p style="{{ p_style }}">If you did not expect this change, please visit the <a href="{{ portal_url }}" style="{{ a_style }}" target="_blank" rel="noopener noreferrer">BioCommons Access Portal</a> or contact support.</p>
+<p style="{{ p_signoff }}">Thank you,</p>
+<p style="{{ p_style }}">BioCommons Access team</p>

--- a/templates/emails/group_approval.html
+++ b/templates/emails/group_approval.html
@@ -1,0 +1,10 @@
+<p style="{{ p_style }}">Dear {{ admin_first_name }},</p>
+<p style="{{ p_style }}">You have received a new request for access to the {{ bundle_name }} Service Bundle.</p>
+<p style="{{ p_style }}">
+    <strong>Name:</strong> {{ requester_full_name }}<br/>
+    <strong>Email:</strong> {{ requester_email }}<br/>
+    <strong>Reason:</strong> {{ reason }}
+</p>
+<p style="{{ p_style }}">Please log into the BioCommons Access bundle dashboard to review and approve or decline this request.</p>
+<p style="{{ p_signoff }}">Thank you,</p>
+<p style="{{ p_style }}">BioCommons Access team</p>

--- a/templates/emails/group_approved.html
+++ b/templates/emails/group_approved.html
@@ -1,0 +1,12 @@
+<p style="{{ p_style }}">Dear {{ first_name }},</p>
+<p style="{{ p_style }}">Your request to join the {{ group_name }}{{ short_suffix }} service bundle has been approved.</p>
+<p style="{{ p_style }}">If you are logged into either of the BioPlatforms Data Portal or Galaxy Australia, please log out and log back in again to ensure your access rights are updated.</p>
+<table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="margin: 24px auto;">
+  <tr>
+    <td align="center">
+      <a href="{{ portal_url }}" target="_blank" rel="noopener noreferrer" style="display: inline-block; background-color: #171717; color: #ffffff; font-weight: 600; padding: 12px 18px; line-height: 20px; border-radius: 8px; text-decoration: none; font-size: 14px;">Go to BioCommons Access Portal</a>
+    </td>
+  </tr>
+</table>
+<p style="{{ p_signoff }}">Thank you,</p>
+<p style="{{ p_style }}">BioCommons Access team</p>

--- a/templates/emails/group_membership_rejected.html
+++ b/templates/emails/group_membership_rejected.html
@@ -1,0 +1,47 @@
+<p style="{{ p_style }}">Dear {{ username }},</p>
+<p style="{{ p_style }}">Thank you for your interest in the {{ group_name }} Bundle.</p>
+<p style="{{ p_style }}">
+    The TSI Bundle available on BioCommons Access is only for members of the
+    <a href="https://bioplatforms.com/project/threatened-species/" target="_blank" rel="noopener noreferrer"
+       style="{{ a_style }}">Threatened Species Initiative</a>
+    consortium.
+</p>
+<p style="{{ p_style }}">
+    Members are collaborators who have projects supported through our request for partnership rounds. They can access
+    datasets that are under embargo for the first 12 months following their generation.
+</p>
+<p style="{{ p_style }}">
+    The <a href="https://bioplatforms.com/project/threatened-species/" target="_blank" rel="noopener noreferrer"
+           style="{{ a_style }}">Threatened Species Initiative</a>
+    is generating genomic resources that are made openly accessible to the community through the Bioplatforms Australia
+    data portal. To obtain access to the open access genomics datasets, you only need to register for an account and you
+    do not need to apply to the TSI Bundle. This is also the case for datasets of all other initiatives presented on the
+    <a href="https://data.bioplatforms.com/all_projects" target="_blank" rel="noopener noreferrer"
+       style="{{ a_style }}">Bioplatforms Data Portal</a>.
+</p>
+<p style="{{ p_style }}">
+    Similarly, various tools - including <a href="https://www.biocommons.org.au/fgenesh-plus-plus" target="_blank"
+                                            rel="noopener noreferrer" style="{{ a_style }}">FGenesh++</a> and AlphaFold,
+    can be directly accessed through <a href="https://site.usegalaxy.org.au/" target="_blank" rel="noopener noreferrer"
+                                        style="{{ a_style }}">Galaxy Australia</a> without the need of the TSI Bundle:
+</p>
+<ul style="{{ ul_style }}">
+    <li style="{{ li_style }}"><a href="https://site.usegalaxy.org.au/request/access" target="_blank"
+                                  rel="noopener noreferrer" style="{{ a_style }}">Request access to specialist tools</a>
+    </li>
+</ul>
+<p style="{{ p_style }}">Please do not hesitate to reach out to us for any non registration related issues:</p>
+<ul style="{{ ul_style }}">
+    <li style="{{ li_style }}">
+        Bioplatforms Australia Data Portal — <a href="mailto:help@bioplatforms.com" style="{{ a_style }}">help@bioplatforms.com</a>
+    </li>
+    <li style="{{ li_style }}">
+        Galaxy Australia — <a href="https://site.usegalaxy.org.au/request/" target="_blank" rel="noopener noreferrer"
+                              style="{{ a_style }}">Galaxy Australia - Help and support</a>
+    </li>
+    <li style="{{ li_style }}">
+        TSI specific enquiries — <a href="mailto:smazard@bioplatforms.com" style="{{ a_style }}">smazard@bioplatforms.com</a>
+    </li>
+</ul>
+<p style="{{ p_signoff }}">Thank you,</p>
+<p style="{{ p_style }}">BioCommons Access Team</p>

--- a/templates/emails/incorrect_email.html
+++ b/templates/emails/incorrect_email.html
@@ -1,0 +1,39 @@
+<p style="{{ p_style }}">Hi {{ first_name }}</p>
+
+<p style="{{ p_style }}">
+    We noticed a recent attempt to register for a BioCommons Access account by you using the email
+    address {{ incorrect_email }}
+</p>
+
+<p style="{{ p_style }}">
+    It looks like there might have been a typo in the signup process that prevented you from receiving
+    your verification email, or you used an email address which cannot receive the verification email.
+</p>
+
+<p style="{{ p_style }}">
+    Since we believe this is your correct address, we wanted to reach out and help you complete
+    an account registration.
+</p>
+
+<p style="{{ p_style }}">
+    If you haven’t already done so, please re-register here using a valid email address.
+</p>
+
+<a href="{{ register_url }}" style="{{ a_style }}" target="_blank" rel="noopener noreferrer">BioCommons Access registration</a>
+
+<p style="{{ p_style }}">
+    If the button doesn't work, you can copy and paste the URL into your browser.
+</p>
+
+<code>
+    {{ register_url }}
+</code>
+
+<p style="{{ p_style }}">
+    If you have already successfully created an account using a valid email address, please feel free to disregard this message.
+</p>
+
+<p style="{{ p_style }}">
+    Best regards,<br/>
+    BioCommons Access team
+</p>

--- a/templates/emails/incorrect_email.html
+++ b/templates/emails/incorrect_email.html
@@ -2,7 +2,7 @@
 
 <p style="{{ p_style }}">
     We noticed a recent attempt to register for a BioCommons Access account by you using the email
-    address {{ incorrect_email }}
+    address <strong>{{ incorrect_email }}</strong>
 </p>
 
 <p style="{{ p_style }}">
@@ -19,15 +19,19 @@
     If you haven’t already done so, please re-register here using a valid email address.
 </p>
 
-<a href="{{ register_url }}" style="{{ a_style }}" target="_blank" rel="noopener noreferrer">BioCommons Access registration</a>
+<p style="{{ p_center_style }}">
+    <a href="{{ register_url }}" style="{{ a_style }}" target="_blank" rel="noopener noreferrer">BioCommons Access registration</a>
+</p>
 
 <p style="{{ p_style }}">
     If the button doesn't work, you can copy and paste the URL into your browser.
 </p>
 
-<code>
-    {{ register_url }}
-</code>
+<p style="{{ p_center_style }}">
+    <code>
+        {{ register_url }}
+    </code>
+</p>
 
 <p style="{{ p_style }}">
     If you have already successfully created an account using a valid email address, please feel free to disregard this message.

--- a/templates/emails/username_changed.html
+++ b/templates/emails/username_changed.html
@@ -1,0 +1,10 @@
+    <p style="{{ p_style }}">Hello,</p>
+    <p style="{{ p_style }}">The username on your Biocommons Access account was updated by your service administrator.</p>
+    <p style="{{ p_style }}">
+        <strong>Old username:</strong> {{ old_username }}<br/>
+        <strong>New username:</strong> {{ new_username }}</p>
+    <p style="{{ p_style }}">
+        If you did not expect this change, please visit the <a href="{{ portal_url }}" style="{{ a_style }}" target="_blank" rel="noopener noreferrer">BioCommons Access Portal</a> or contact support.
+    </p>
+    <p style="{{ p_signoff }}">Thank you,</p>
+    <p style="{{ p_style }}">BioCommons Access team</p>

--- a/templates/emails/welcome_email.html
+++ b/templates/emails/welcome_email.html
@@ -1,0 +1,45 @@
+<p style="{{ p_style }}">Dear {{ first_name }},</p>
+<p style="{{ p_style }}">Welcome to your new BioCommons Access account!</p>
+<p style="{{ p_style }}">
+    <strong><a href="https://www.biocommons.org.au/access" target="_blank"
+               rel="noopener noreferrer" style="{{ a_style }}">BioCommons Access</a> is your key to
+        unlocking analysis services and research data across the Australian BioCommons ecosystem. A single log in offers
+        convenient and secure access to a growing number of services.</strong>
+</p>
+<p style="{{ p_style }}">
+    Consider bookmarking <a href="{{ portal_url }}" target="_blank" rel="noopener noreferrer"
+                            style="{{ a_style }}">{{ portal_url }}</a> for future logins. Use the
+    BioCommons Access portal to access connected services, update your profile and apply for Service Bundles.
+</p>
+<table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="margin: 24px auto;">
+    <tr>
+        <td align="center">
+            <a href="{{ portal_url }}" target="_blank" rel="noopener noreferrer"
+               style="display: inline-block; background-color: #171717; color: #ffffff; font-weight: 600; padding: 12px 18px; line-height: 20px; border-radius: 8px; text-decoration: none; font-size: 14px;">BioCommons
+                Access Login</a>
+        </td>
+    </tr>
+</table>
+<p style="{{ p_style }}">
+    The BioCommons Access portal contains links to services including Galaxy Australia and the
+    Bioplatforms Australia Data Portal. You can also access these services directly with your BioCommons Access
+    credentials.
+</p>
+<p style="{{ p_style }}">
+    You can <a href="https://biocommonsaccess.freshdesk.com/support/home" target="_blank"
+               rel="noopener noreferrer" style="{{ a_style }}">access support for your BioCommons Access
+    account</a>, or find help related to <a href="https://www.biocommons.org.au/access-existing-users" target="_blank"
+                                            rel="noopener noreferrer" style="{{ a_style }}">migrating existing Galaxy Australia
+    or Bioplatforms Australia Data Portal accounts</a>.
+</p>
+<p style="{{ p_style }}">
+    To hear when future services come online, as well as relevant training and other ways to
+    connect, <a href="https://www.biocommons.org.au/subscribe" target="_blank" rel="noopener noreferrer" style="{{ a_style }}">subscribe
+    to the Australian BioCommons monthly newsletter</a>.
+</p>
+<p style="{{ p_signoff }}">Thank you,</p>
+<p style="{{ p_style }}">
+    The Australian BioCommons<br/><a href="https://www.biocommons.org.au" target="_blank"
+                                     rel="noopener noreferrer"
+                                     style="{{ a_style }}">www.biocommons.org.au</a>
+</p>

--- a/tests/admin_api/test_admin.py
+++ b/tests/admin_api/test_admin.py
@@ -670,6 +670,42 @@ def test_delete_user_invalid_email_soft_deletes_user_and_queues_email(
     assert "incorrect@example.org" in queued_emails[0].body_html
 
 
+def test_delete_user_invalid_email_defaults_missing_reason(
+    test_client,
+    test_db_session,
+    as_admin_user,
+    mock_auth0_client,
+    galaxy_platform,
+    persistent_factories,
+):
+    mock_auth0_client.update_user.return_value = True
+    mock_auth0_client.delete_user_refresh_tokens.return_value = True
+    user = _create_user_with_platform_membership(
+        db_session=test_db_session,
+        platform_id=galaxy_platform.id,
+    )
+    mock_auth0_client.get_user.return_value = Auth0UserDataFactory.build(
+        user_id=user.id,
+        email="incorrect@example.org",
+        given_name="Grace",
+    )
+
+    resp = test_client.post(
+        f"/admin/users/{user.id}/delete_invalid_email",
+        json={"correct_email": "correct@example.org"},
+    )
+
+    assert resp.status_code == 200
+    test_db_session.expire_all()
+    deleted_user = BiocommonsUser.get_deleted_by_id(test_db_session, user.id)
+    assert deleted_user.deletion_reason == "Invalid email address"
+
+    queued_emails = test_db_session.exec(select(EmailNotification)).all()
+    assert len(queued_emails) == 1
+    assert queued_emails[0].to_address == "correct@example.org"
+    assert queued_emails[0].status == EmailStatusEnum.PENDING
+
+
 @respx.mock
 def test_delete_user_continue_when_refresh_token_delete_fails(test_client, test_db_session, as_admin_user, test_auth0_client, galaxy_platform, persistent_factories):
     """

--- a/tests/admin_api/test_admin.py
+++ b/tests/admin_api/test_admin.py
@@ -706,6 +706,53 @@ def test_delete_user_invalid_email_defaults_missing_reason(
     assert queued_emails[0].status == EmailStatusEnum.PENDING
 
 
+def test_delete_user_invalid_email_does_not_delete_when_email_queue_fails(
+    test_client,
+    test_db_session,
+    as_admin_user,
+    mock_auth0_client,
+    galaxy_platform,
+    persistent_factories,
+    mocker,
+):
+    mock_auth0_client.update_user.return_value = True
+    mock_auth0_client.delete_user_refresh_tokens.return_value = True
+    user = _create_user_with_platform_membership(
+        db_session=test_db_session,
+        platform_id=galaxy_platform.id,
+    )
+    mock_auth0_client.get_user.return_value = Auth0UserDataFactory.build(
+        user_id=user.id,
+        email="incorrect@example.org",
+        given_name="Grace",
+    )
+    mocker.patch(
+        "routers.admin.enqueue_email",
+        side_effect=RuntimeError("queue unavailable"),
+    )
+
+    resp = test_client.post(
+        f"/admin/users/{user.id}/delete_invalid_email",
+        json={
+            "reason": "User registered with the wrong email address",
+            "correct_email": "correct@example.org",
+        },
+    )
+
+    assert resp.status_code == 500
+    assert resp.json()["detail"] == "Failed to queue incorrect email notification."
+    test_db_session.expire_all()
+    refreshed_user = BiocommonsUser.get_by_id(user.id, test_db_session)
+    assert refreshed_user is not None
+    assert refreshed_user.is_deleted is False
+    assert refreshed_user.deletion_reason is None
+    mock_auth0_client.update_user.assert_not_called()
+    mock_auth0_client.delete_user_refresh_tokens.assert_not_called()
+
+    queued_emails = test_db_session.exec(select(EmailNotification)).all()
+    assert len(queued_emails) == 0
+
+
 @respx.mock
 def test_delete_user_continue_when_refresh_token_delete_fails(test_client, test_db_session, as_admin_user, test_auth0_client, galaxy_platform, persistent_factories):
     """

--- a/tests/admin_api/test_admin.py
+++ b/tests/admin_api/test_admin.py
@@ -720,6 +720,7 @@ def test_delete_user_invalid_email_does_not_delete_when_email_queue_fails(
     user = _create_user_with_platform_membership(
         db_session=test_db_session,
         platform_id=galaxy_platform.id,
+        deletion_reason=None
     )
     mock_auth0_client.get_user.return_value = Auth0UserDataFactory.build(
         user_id=user.id,

--- a/tests/admin_api/test_admin.py
+++ b/tests/admin_api/test_admin.py
@@ -613,6 +613,63 @@ def test_delete_user_calls_auth0_api(test_client, test_db_session, as_admin_user
     mock_auth0_client.delete_user_refresh_tokens.assert_called_once_with(user_id=user_id)
 
 
+def test_delete_user_invalid_email_soft_deletes_user_and_queues_email(
+    test_client,
+    test_db_session,
+    as_admin_user,
+    mock_auth0_client,
+    galaxy_platform,
+    persistent_factories,
+    frozen_time,
+):
+    mock_auth0_client.update_user.return_value = True
+    mock_auth0_client.delete_user_refresh_tokens.return_value = True
+    user = _create_user_with_platform_membership(
+        db_session=test_db_session,
+        platform_id=galaxy_platform.id,
+    )
+    user_id = user.id
+    mock_auth0_client.get_user.return_value = Auth0UserDataFactory.build(
+        user_id=user_id,
+        email="incorrect@example.org",
+        given_name="Grace",
+    )
+
+    resp = test_client.post(
+        f"/admin/users/{user_id}/delete_invalid_email",
+        json={
+            "reason": "User registered with the wrong email address",
+            "correct_email": "correct@example.org",
+        },
+    )
+
+    assert resp.status_code == 200
+    test_db_session.expire_all()
+    user_query = select(func.count()).select_from(BiocommonsUser).where(BiocommonsUser.id == user_id)
+    assert test_db_session.exec(user_query).one() == 0
+    assert test_db_session.exec(user_query.execution_options(include_deleted=True)).one() == 1
+
+    deleted_user = BiocommonsUser.get_deleted_by_id(test_db_session, user_id)
+    assert deleted_user.is_deleted
+    assert deleted_user.deleted_at == frozen_time
+    assert deleted_user.deleted_by == as_admin_user
+    assert deleted_user.deletion_reason == "User registered with the wrong email address"
+    mock_auth0_client.update_user.assert_called_once_with(
+        user_id=user_id,
+        update_data=UpdateUserData(blocked=True),
+    )
+    mock_auth0_client.delete_user_refresh_tokens.assert_called_once_with(user_id=user_id)
+    mock_auth0_client.get_user.assert_called_once_with(user_id)
+
+    queued_emails = test_db_session.exec(select(EmailNotification)).all()
+    assert len(queued_emails) == 1
+    assert queued_emails[0].to_address == "correct@example.org"
+    assert queued_emails[0].status == EmailStatusEnum.PENDING
+    assert queued_emails[0].subject == "Did you register for a BioCommons Access account?"
+    assert "Hi Grace" in queued_emails[0].body_html
+    assert "incorrect@example.org" in queued_emails[0].body_html
+
+
 @respx.mock
 def test_delete_user_continue_when_refresh_token_delete_fails(test_client, test_db_session, as_admin_user, test_auth0_client, galaxy_platform, persistent_factories):
     """

--- a/tests/biocommons/test_emails.py
+++ b/tests/biocommons/test_emails.py
@@ -349,7 +349,7 @@ def test_compose_incorrect_email_notification_email_trims_portal_url_trailing_sl
     assert_email_contains(
         html,
         "Hi Grace",
-        "address grace.typo@example.org",
+        "grace.typo@example.org",
         'href="https://portal.example.org/register"',
         "https://portal.example.org/register",
         "BioCommons Access registration",

--- a/tests/biocommons/test_emails.py
+++ b/tests/biocommons/test_emails.py
@@ -7,6 +7,7 @@ from biocommons.emails import (
     compose_group_approval_email,
     compose_group_membership_approved_email,
     compose_group_membership_rejected_email,
+    compose_incorrect_email_notification_email,
     compose_username_change_notification,
     compose_welcome_email,
     format_first_name,
@@ -333,3 +334,24 @@ def test_compose_bundle_request_confirmation_email_defaults_missing_reason(mock_
     )
 
     assert "<strong>Reason provided:</strong> Not provided" in html
+
+
+def test_compose_incorrect_email_notification_email_trims_portal_url_trailing_slash(mock_settings):
+    mock_settings.aai_portal_url = "https://portal.example.org/"
+
+    subject, html = compose_incorrect_email_notification_email(
+        first_name="Grace",
+        incorrect_email="grace.typo@example.org",
+        settings=mock_settings,
+    )
+
+    assert subject == "Did you register for a BioCommons Access account?"
+    assert_email_contains(
+        html,
+        "Hi Grace",
+        "address grace.typo@example.org",
+        'href="https://portal.example.org/register"',
+        "https://portal.example.org/register",
+        "BioCommons Access registration",
+    )
+    assert "https://portal.example.org//register" not in html

--- a/tests/biocommons/test_emails.py
+++ b/tests/biocommons/test_emails.py
@@ -1,13 +1,29 @@
 from types import SimpleNamespace
 
 from biocommons.emails import (
+    compose_bundle_request_confirmation_email,
+    compose_email_change_notification,
+    compose_email_change_otp_email,
+    compose_group_approval_email,
+    compose_group_membership_approved_email,
+    compose_group_membership_rejected_email,
+    compose_username_change_notification,
+    compose_welcome_email,
     format_first_name,
     format_full_name,
     get_default_sender_email,
     get_group_admin_contacts,
+    render_default_email_html,
+    render_html_template,
 )
 from db.models import Auth0Role, BiocommonsGroup
 from tests.datagen import RoleUserDataFactory
+
+
+def assert_email_contains(html: str, *expected: str) -> None:
+    normalized_html = " ".join(html.split())
+    for text in expected:
+        assert " ".join(text.split()) in normalized_html
 
 
 def test_get_default_sender(mock_settings):
@@ -93,3 +109,227 @@ def test_get_group_admin_contacts_dedupes_and_falls_back(mocker):
         "b@example.com": "Bea",
         "c@example.com": "Charlie",
     }
+
+
+def test_render_default_email_html_renders_common_email_frame():
+    html = render_default_email_html(
+        title="Test & Email",
+        preheader="Preview text",
+        body_html="<p>Hello <strong>Ada</strong></p>",
+        portal_url="https://portal.example.org",
+        icon_url="https://example.org/icon.png",
+        logo_url="https://example.org/logo.png",
+    )
+
+    assert_email_contains(
+        html,
+        "<title>Test &amp; Email</title>",
+        "Preview text",
+        '<a href="https://portal.example.org"',
+        '<img src="https://example.org/logo.png" alt="BioCommons Logo"',
+        '<img src="https://example.org/icon.png"',
+        "<p>Hello <strong>Ada</strong></p>",
+        "FAQs or contact support",
+    )
+
+
+def test_render_html_template_renders_template_with_default_styles():
+    html = render_html_template(
+        "emails/group_approval.html",
+        admin_first_name="Ada <Admin>",
+        bundle_name="Galaxy & Data",
+        requester_full_name="Grace Hopper",
+        requester_email="grace@example.org",
+        reason="Research access",
+    )
+
+    assert_email_contains(
+        html,
+        "Dear Ada &lt;Admin&gt;",
+        "Galaxy &amp; Data Service Bundle",
+        "<strong>Name:</strong> Grace Hopper",
+        "<strong>Email:</strong> grace@example.org",
+        "<strong>Reason:</strong> Research access",
+        "font-size: 16px",
+    )
+
+
+def test_compose_group_approval_email(mock_settings):
+    subject, html = compose_group_approval_email(
+        admin_first_name="Ada",
+        bundle_name="Threatened Species",
+        requester_full_name="Grace Hopper",
+        requester_email="grace@example.org",
+        request_reason="Genome analysis",
+        settings=mock_settings,
+    )
+
+    assert subject == "Threatened Species Service Bundle request"
+    assert_email_contains(
+        html,
+        "Dear Ada,",
+        "new request for access to the Threatened Species Service Bundle",
+        "<strong>Name:</strong> Grace Hopper",
+        "<strong>Email:</strong> grace@example.org",
+        "<strong>Reason:</strong> Genome analysis",
+    )
+
+
+def test_compose_group_approval_email_defaults_missing_reason(mock_settings):
+    _, html = compose_group_approval_email(
+        admin_first_name="Ada",
+        bundle_name="Threatened Species",
+        requester_full_name="Grace Hopper",
+        requester_email="grace@example.org",
+        request_reason=None,
+        settings=mock_settings,
+    )
+
+    assert "<strong>Reason:</strong> Not provided" in html
+
+
+def test_compose_group_membership_approved_email(mock_settings):
+    subject, html = compose_group_membership_approved_email(
+        group_name="Threatened Species",
+        group_short_name="TSI",
+        first_name="Grace",
+        settings=mock_settings,
+    )
+
+    assert subject == "Threatened Species Service Bundle access approved"
+    assert_email_contains(
+        html,
+        "Dear Grace,",
+        "Your request to join the Threatened Species (TSI) service bundle has been approved.",
+        "Go to BioCommons Access Portal",
+        f'href="{mock_settings.aai_portal_url}"',
+    )
+
+
+def test_compose_group_membership_approved_email_omits_duplicate_short_name(mock_settings):
+    _, html = compose_group_membership_approved_email(
+        group_name="Galaxy",
+        group_short_name="Galaxy",
+        first_name="Grace",
+        settings=mock_settings,
+    )
+
+    assert "Galaxy (Galaxy) service bundle" not in html
+    assert "Galaxy service bundle has been approved" in html
+
+
+def test_compose_email_change_notification(mock_settings):
+    subject, html = compose_email_change_notification(
+        old_email="old@example.org",
+        new_email="new@example.org",
+        settings=mock_settings,
+    )
+
+    assert subject == "Your Biocommons Access email address was updated"
+    assert_email_contains(
+        html,
+        "The email address on your Biocommons Access account was updated.",
+        "<strong>Old email:</strong> old@example.org",
+        "<strong>New email:</strong> new@example.org",
+        f'href="{mock_settings.aai_portal_url}"',
+    )
+
+
+def test_compose_username_change_notification(mock_settings):
+    subject, html = compose_username_change_notification(
+        old_username="old-user",
+        new_username="new-user",
+        settings=mock_settings,
+    )
+
+    assert subject == "Your Biocommons Access username was updated"
+    assert_email_contains(
+        html,
+        "The username on your Biocommons Access account was updated by your service administrator.",
+        "<strong>Old username:</strong> old-user",
+        "<strong>New username:</strong> new-user",
+        f'href="{mock_settings.aai_portal_url}"',
+    )
+
+
+def test_compose_email_change_otp_email():
+    subject, html = compose_email_change_otp_email(
+        code="123456",
+        target_email="new@example.org",
+        expiration_minutes=15,
+        portal_url="https://portal.example.org",
+    )
+
+    assert subject == "Confirm your new BioCommons Access email address"
+    assert_email_contains(
+        html,
+        "change the email address of your BioCommons Access account to new@example.org",
+        "Your verification code is <strong>123456</strong>.",
+        "This code is valid for 15 minutes.",
+        'href="https://portal.example.org"',
+    )
+
+
+def test_compose_welcome_email():
+    subject, html = compose_welcome_email(
+        first_name="Grace",
+        portal_url="https://portal.example.org",
+    )
+
+    assert subject == "Welcome to BioCommons Access"
+    assert_email_contains(
+        html,
+        "Dear Grace,",
+        "Welcome to your new BioCommons Access account!",
+        "BioCommons Access Login",
+        'href="https://portal.example.org"',
+        "subscribe to the Australian BioCommons monthly newsletter",
+    )
+
+
+def test_compose_group_membership_rejected_email(mock_settings):
+    subject, html = compose_group_membership_rejected_email(
+        group_name="Threatened Species",
+        username="Grace",
+        settings=mock_settings,
+    )
+
+    assert subject == "Threatened Species Initiative service bundle request"
+    assert_email_contains(
+        html,
+        "Dear Grace,",
+        "Thank you for your interest in the Threatened Species Bundle.",
+        "Threatened Species Initiative",
+        "Request access to specialist tools",
+        "help@bioplatforms.com",
+        "BioCommons Access Team",
+    )
+
+
+def test_compose_bundle_request_confirmation_email(mock_settings):
+    subject, html = compose_bundle_request_confirmation_email(
+        first_name="Grace",
+        bundle_name="Threatened Species",
+        request_reason="Genome analysis",
+        settings=mock_settings,
+    )
+
+    assert subject == "Your Threatened Species Service Bundle request has been received"
+    assert_email_contains(
+        html,
+        "Dear Grace,",
+        "Thank you for submitting a request to join the <strong>Threatened Species</strong> Service Bundle.",
+        "<strong>Bundle requested:</strong> Threatened Species",
+        "<strong>Reason provided:</strong> Genome analysis",
+    )
+
+
+def test_compose_bundle_request_confirmation_email_defaults_missing_reason(mock_settings):
+    _, html = compose_bundle_request_confirmation_email(
+        first_name="Grace",
+        bundle_name="Threatened Species",
+        request_reason=None,
+        settings=mock_settings,
+    )
+
+    assert "<strong>Reason provided:</strong> Not provided" in html

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,6 +4,16 @@ from pydantic import ValidationError
 from config import Settings
 
 
+@pytest.fixture(autouse=True)
+def clear_settings_env(monkeypatch):
+    """
+    Ensure config env variables are cleared before each test.
+    """
+    for field_name in Settings.model_fields:
+        env_name = field_name.upper()
+        monkeypatch.delenv(env_name, raising=False)
+
+
 def _base_settings_kwargs():
     return {
         "auth0_domain": "mock-domain",


### PR DESCRIPTION
## Description

[AAI-829](https://biocloud.atlassian.net/browse/AAI-829): add an endpoint to delete accounts with incorrect email - and notify users.

## Changes

- Switch to Jinja2 templates for emails - less HTML in our code, and allows tighter control of escaping and template variables
- Add template for notifying users about incorrect emails
- Admin endpoint: `POST /users/{user_id}/delete_invalid_email`
- Unit tests

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit / integration tests that prove my fix is effective or that my feature works
- [x] I have run all tests locally and they pass
- [x] I have updated the documentation (if applicable)
- [ ] For any new secrets, I have updated the [shared spreadsheet](https://docs.google.com/spreadsheets/d/16lGloFh4VxMmu6cJdeFVLy2654hdq-ZeErhB8UifSfI/edit?usp=sharing) and the [GitHub Secrets](https://github.com/AustralianBioCommons/aai-backend/settings/secrets/actions).

## How to Test Manually (if necessary)

Run `uv run pytest`

Example email:


<img width="981" height="805" alt="Screenshot 2026-05-22 at 12 54 18 pm" src="https://github.com/user-attachments/assets/79afc965-92e7-4beb-972f-ccbf2a066857" />


[AAI-829]: https://biocloud.atlassian.net/browse/AAI-829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ