### PR TITLE
fix: incorrect check of institutional email when requesting SBP bundle

### DIFF
--- a/routers/user.py
+++ b/routers/user.py
@@ -503,7 +503,8 @@ def request_group_access(
     """
     has_sbp_request = any(item.group_id == GroupEnum.SBP.value for item in request_data.groups)
     if has_sbp_request:
-        is_institution = asyncio.run(is_australian_research_institution_email(user.access_token.email))
+        is_institution = asyncio.run(is_australian_research_institution_email(db_user.email))
+
         if not is_institution:
             raise HTTPException(
                 status_code=http.HTTPStatus.FORBIDDEN,

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -423,8 +423,11 @@ def test_request_group_membership_checks_email_for_sbp(
     mocker,
 ):
     group = BiocommonsGroupFactory.create_sync(group_id=GroupEnum.SBP.value)
-    BiocommonsUserFactory.create_sync(group_memberships=[], id=normal_user.access_token.sub)
-    normal_user.access_token.email = "external@example.com"
+    BiocommonsUserFactory.create_sync(
+        group_memberships=[],
+        id=normal_user.access_token.sub,
+        email="external@example.com"
+    )
     institution_check = mocker.patch(
         "routers.user.is_australian_research_institution_email",
         new=AsyncMock(return_value=False),
@@ -445,6 +448,35 @@ def test_request_group_membership_checks_email_for_sbp(
     )
     assert membership is None
 
+
+@pytest.mark.asyncio
+async def test_request_group_membership_allows_biocommons(
+        test_client,
+        normal_user,
+        as_normal_user,
+        test_db_session,
+        persistent_factories,
+        mocker,
+):
+    group = BiocommonsGroupFactory.create_sync(group_id=GroupEnum.SBP.value)
+    BiocommonsUserFactory.create_sync(
+        group_memberships=[],
+        id=normal_user.access_token.sub,
+        email="user@biocommons.org.au"
+    )
+
+    resp = test_client.post(
+        "/me/groups/request",
+        json={"groups": [{"group_id": group.group_id, "request_reason": "Need SBP workflow access"}]},
+    )
+
+    assert resp.status_code == 200
+    membership = GroupMembership.get_by_user_id_and_group_id(
+        user_id=normal_user.access_token.sub,
+        group_id=group.group_id,
+        session=test_db_session,
+    )
+    assert membership.approval_status == ApprovalStatusEnum.PENDING
 
 @respx.mock
 def test_request_group_membership_after_rejection(


### PR DESCRIPTION
## Description

Requesting the SBP bundle failed for existing users because the institutional email check looked for the email in the wrong place

## Changes

- Fix the email check
- Add a unit test to ensure the biocommons whitelist is working

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit / integration tests that prove my fix is effective or that my feature works
- [x] I have run all tests locally and they pass
- [x] I have updated the documentation (if applicable)
- [ ] For any new secrets, I have updated the [shared spreadsheet](https://docs.google.com/spreadsheets/d/16lGloFh4VxMmu6cJdeFVLy2654hdq-ZeErhB8UifSfI/edit?usp=sharing) and the [GitHub Secrets](https://github.com/AustralianBioCommons/aai-backend/settings/secrets/actions).

## How to Test Manually (if necessary)

Run `uv run pytest`
