### PR TITLE
fix: unverified users failing to refresh

### DIFF
--- a/db/utils.py
+++ b/db/utils.py
@@ -46,16 +46,23 @@ def refresh_unverified_users_task(auth0_client: Auth0Client | None = None, sessi
     LAST_UNVERIFIED_REFRESH_TIME = datetime.now(UTC)
 
     owns_session = session is None
+    auth0_client_dependency = None
     if session is None:
         session = Session(get_engine())
     if auth0_client is None:
         settings = get_settings()
         token = get_management_token(settings)
-        auth0_client = get_auth0_client(settings=settings, management_token=token)
+        auth0_client_dependency = get_auth0_client(settings=settings, management_token=token)
+        auth0_client = next(auth0_client_dependency)
+        if auth0_client is None:
+            raise ValueError("Failed to obtain Auth0 client for user refresh task")
 
     try:
         refresh_unverified_users(session, auth0_client)
     finally:
         if owns_session:
             session.close()
-        auth0_client.close()
+        if auth0_client_dependency is not None:
+            auth0_client_dependency.close()
+        else:
+            auth0_client.close()

--- a/tests/db/test_utils.py
+++ b/tests/db/test_utils.py
@@ -41,6 +41,36 @@ def test_refresh_unverified_users_throttling(test_db_session):
             auth0_client.get_user.assert_not_called()
 
 
+def test_refresh_unverified_users_task_gets_auth0_client_when_none(test_db_session):
+    """Verifies the task obtains and keeps an Auth0 client open when none is passed."""
+    settings = MagicMock()
+    auth0_client = MagicMock()
+
+    def auth0_client_dependency(**kwargs):
+        assert kwargs == {"settings": settings, "management_token": "management-token"}
+        try:
+            yield auth0_client
+        finally:
+            auth0_client.close()
+
+    def assert_client_open_during_refresh(session, client):
+        assert session is test_db_session
+        assert client is auth0_client
+        auth0_client.close.assert_not_called()
+
+    with (
+        patch("db.utils.get_settings", return_value=settings),
+        patch("db.utils.get_management_token", return_value="management-token") as mock_get_management_token,
+        patch("db.utils.get_auth0_client", side_effect=auth0_client_dependency),
+        patch("db.utils.refresh_unverified_users", side_effect=assert_client_open_during_refresh) as mock_refresh,
+    ):
+        refresh_unverified_users_task(auth0_client=None, session=test_db_session)
+
+    mock_get_management_token.assert_called_once_with(settings)
+    mock_refresh.assert_called_once_with(test_db_session, auth0_client)
+    auth0_client.close.assert_called_once()
+
+
 def test_refresh_unverified_users_updates_status(test_db_session: Session):
     """Verifies that a user's status is updated when Auth0 reports they are now verified."""
     # Create an unverified user


### PR DESCRIPTION
## Description

Unverified users are failing to refresh: we have a background task for it but there's a bug where it fails to grab the Auth0Client correctly

## Changes

- Fix lookup of Auth0Client
- Add a unit test to catch this if it happens again