### PR TITLE
fix: render button for registration link

### DIFF
--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -1,3 +1,4 @@
 module.exports = {
-  extends: ['@commitlint/config-conventional']
+  extends: ['@commitlint/config-conventional'],
+  ignores: [(message) => message.includes('dependabot[bot]')],
 };

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -1,4 +1,3 @@
 module.exports = {
-  extends: ['@commitlint/config-conventional'],
-  ignores: [(message) => message.includes('dependabot[bot]')],
+  extends: ['@commitlint/config-conventional']
 };

--- a/templates/emails/incorrect_email.html
+++ b/templates/emails/incorrect_email.html
@@ -19,9 +19,20 @@
     If you haven’t already done so, please re-register here using a valid email address.
 </p>
 
-<p style="{{ p_center_style }}">
-    <a href="{{ register_url }}" style="{{ a_style }}" target="_blank" rel="noopener noreferrer">BioCommons Access registration</a>
-</p>
+<table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="margin: 24px auto">
+    <tr>
+        <td align="center">
+            <a
+                href="{{ register_url }}"
+                target="_blank"
+                rel="noopener noreferrer"
+                style="display: inline-block; background-color: #171717; color: #ffffff; font-weight: 600; padding: 12px 18px; line-height: 20px; border-radius: 8px; text-decoration: none; font-size: 14px;"
+            >
+                BioCommons Access registration
+            </a>
+        </td>
+    </tr>
+</table>
 
 <p style="{{ p_style }}">
     If the button doesn't work, you can copy and paste the URL into your browser.


### PR DESCRIPTION
## Description

[AAI-832](https://biocloud.atlassian.net/browse/AAI-832): Render the templated button for registeration link in the incorrect email

## Changes

- Render the templated button for registeration link in the incorrect email

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit / integration tests that prove my fix is effective or that my feature works
- [x] I have run all tests locally and they pass
- [x] I have updated the documentation (if applicable)
- [ ] For any new secrets, I have updated the [shared spreadsheet](https://docs.google.com/spreadsheets/d/16lGloFh4VxMmu6cJdeFVLy2654hdq-ZeErhB8UifSfI/edit?usp=sharing) and the [GitHub Secrets](https://github.com/AustralianBioCommons/aai-backend/settings/secrets/actions).

## How to Test Manually (if necessary)

<img width="1512" height="907" alt="Screenshot 2026-05-29 at 11 52 03 am" src="https://github.com/user-attachments/assets/42b33ee4-fc82-429c-8b8d-a0ef44e1b7e7" />



[AAI-832]: https://biocloud.atlassian.net/browse/AAI-832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ