### PR TITLE
fix: do not lint dependabot commits

### DIFF
--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -1,3 +1,4 @@
 module.exports = {
-  extends: ['@commitlint/config-conventional']
+  extends: ['@commitlint/config-conventional'],
+  ignores: [(message) => message.includes('dependabot[bot]')],
 };


### PR DESCRIPTION
## Description

Make a special case for dependabot commits since[ it usually includes urls that can go pretty long](https://github.com/AustralianBioCommons/aai-portal/pull/238)...

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit / integration tests that prove my fix is effective or that my feature works
- [x] I have run all tests locally and they pass
- [x] I have updated the documentation (if applicable)
- [ ] For any new secrets, I have updated the [shared spreadsheet](https://docs.google.com/spreadsheets/d/16lGloFh4VxMmu6cJdeFVLy2654hdq-ZeErhB8UifSfI/edit?usp=sharing) and the [GitHub Secrets](https://github.com/AustralianBioCommons/aai-backend/settings/secrets/actions).

## How to Test Manually (if necessary)

CI tests shall pass