### PR TITLE
fix: add more clear rejection message in TSI rejection email

### DIFF
--- a/templates/emails/group_membership_rejected.html
+++ b/templates/emails/group_membership_rejected.html
@@ -1,5 +1,6 @@
 <p style="{{ p_style }}">Dear {{ username }},</p>
 <p style="{{ p_style }}">Thank you for your interest in the {{ group_name }} Bundle.</p>
+<p style="{{ p_style }}">You have not been granted access.</p>
 <p style="{{ p_style }}">
     The TSI Bundle available on BioCommons Access is only for members of the
     <a href="https://bioplatforms.com/project/threatened-species/" target="_blank" rel="noopener noreferrer"

--- a/tests/biocommons/test_emails.py
+++ b/tests/biocommons/test_emails.py
@@ -300,6 +300,7 @@ def test_compose_group_membership_rejected_email(mock_settings):
         html,
         "Dear Grace,",
         "Thank you for your interest in the Threatened Species Bundle.",
+        "You have not been granted access.",
         "Threatened Species Initiative",
         "Request access to specialist tools",
         "help@bioplatforms.com",


### PR DESCRIPTION
## Description

[AAI-813](https://biocloud.atlassian.net/browse/AAI-813): Be more clear on the rejection message in the TSI bundle rejection email. 

As per Sophie'e request https://biocloud.atlassian.net/browse/BAO-17?focusedCommentId=28099.

## Changes

- Update the TSI bundle rejection email

## Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit / integration tests that prove my fix is effective or that my feature works
- [x] I have run all tests locally and they pass
- [x] I have updated the documentation (if applicable)
- [ ] For any new secrets, I have updated the [shared spreadsheet](https://docs.google.com/spreadsheets/d/16lGloFh4VxMmu6cJdeFVLy2654hdq-ZeErhB8UifSfI/edit?usp=sharing) and the [GitHub Secrets](https://github.com/AustralianBioCommons/aai-backend/settings/secrets/actions).

## How to Test Manually (if necessary)

Will deploy and check the visuals after merge.

[AAI-813]: https://biocloud.atlassian.net/browse/AAI-813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ