### PR TITLE
feat: remind SBP bundle users when they change their emails

### DIFF
--- a/routers/user.py
+++ b/routers/user.py
@@ -840,7 +840,6 @@ async def continue_email_update(
     await _revoke_sbp_if_non_institutional(
         user_id=user.access_token.sub,
         new_email=resp.email,
-        db_user=db_user,
         auth0_client=auth0_client,
         db_session=db_session,
     )
@@ -851,7 +850,6 @@ async def _revoke_sbp_if_non_institutional(
     *,
     user_id: str,
     new_email: str,
-    db_user: BiocommonsUser,
     auth0_client: Auth0Client,
     db_session: Session,
 ) -> None:
@@ -893,7 +891,8 @@ async def _revoke_sbp_if_non_institutional(
     sbp_membership.revoke(
         auth0_client=auth0_client,
         reason="Email changed to a non-Australian institutional address.",
-        updated_by=db_user,
+        # Automatic, system-triggered revocation — not a deliberate user action.
+        updated_by=None,
         session=db_session,
         commit=True,
     )

--- a/routers/user.py
+++ b/routers/user.py
@@ -60,7 +60,10 @@ from schemas.biocommons import (
 from schemas.responses import FieldError, FieldErrorResponse
 from schemas.user import SessionUser
 from services.email_queue import enqueue_email
-from services.institutions import is_australian_research_institution_email
+from services.institutions import (
+    check_australian_research_institution_email,
+    is_australian_research_institution_email,
+)
 
 router = APIRouter(
     prefix="/me", tags=["user"], responses={401: {"description": "Unauthorized"}}
@@ -833,7 +836,67 @@ async def continue_email_update(
         updated_by=db_user,
         session=db_session, commit=True
     )
+
+    await _revoke_sbp_if_non_institutional(
+        user_id=user.access_token.sub,
+        new_email=resp.email,
+        db_user=db_user,
+        auth0_client=auth0_client,
+        db_session=db_session,
+    )
     return resp
+
+
+async def _revoke_sbp_if_non_institutional(
+    *,
+    user_id: str,
+    new_email: str,
+    db_user: BiocommonsUser,
+    auth0_client: Auth0Client,
+    db_session: Session,
+) -> None:
+    """
+    Access to the SBP Workflow Execution bundle requires affiliation with an
+    Australian research institution. When a user changes their email, revoke an
+    existing approved SBP bundle (and its backing Auth0 role) if the new address
+    is no longer institutional.
+
+    Only revokes on a *definitive* non-institutional answer from the upstream
+    validator: an indeterminate result (e.g. upstream outage) is logged and left
+    untouched rather than wrongly stripping a user's access.
+    """
+    sbp_membership = GroupMembership.get_by_user_id_and_group_id(
+        user_id=user_id,
+        group_id=GroupEnum.SBP.value,
+        session=db_session,
+    )
+    if (
+        sbp_membership is None
+        or sbp_membership.approval_status != ApprovalStatusEnum.APPROVED
+    ):
+        return
+
+    is_institution = await check_australian_research_institution_email(new_email)
+    if is_institution is None:
+        logger.warning(
+            f"Could not validate institution status for {user_id} after email "
+            f"change; leaving SBP bundle untouched."
+        )
+        return
+    if is_institution:
+        return
+
+    logger.info(
+        f"Revoking SBP bundle for user {user_id}: email changed to a "
+        f"non-institutional address."
+    )
+    sbp_membership.revoke(
+        auth0_client=auth0_client,
+        reason="Email changed to a non-Australian institutional address.",
+        updated_by=db_user,
+        session=db_session,
+        commit=True,
+    )
 
 
 @router.post(

--- a/routers/utils.py
+++ b/routers/utils.py
@@ -1,7 +1,6 @@
 import logging
 from typing import Annotated, Literal
 
-from email_validator import validate_email
 from fastapi import APIRouter, HTTPException, Query
 from fastapi.params import Depends
 from pydantic import BaseModel, EmailStr
@@ -156,11 +155,6 @@ async def check_australian_research_institution(
     Check whether the email domain belongs to an Australian Research Institution
     as listed at https://site.usegalaxy.org.au/list-of-institutions.html.
     """
-    # Allow domains not in Galaxy's list
-    EXTRA_DOMAINS = ["biocommons.org.au"]
-    parsed = validate_email(email, check_deliverability=False)
-    if parsed.domain in EXTRA_DOMAINS:
-        return AustralianResearchInstitutionResponse(is_australian_research_institution=True)
     return AustralianResearchInstitutionResponse(
         is_australian_research_institution=await is_australian_research_institution_email(email),
     )

--- a/services/institutions.py
+++ b/services/institutions.py
@@ -1,6 +1,24 @@
+from typing import Optional
+
 import httpx
 
 GALAXY_AU_VALIDATE_URL = "https://site.usegalaxy.org.au/institution/validate"
+
+
+async def check_australian_research_institution_email(email: str) -> Optional[bool]:
+    """Check email against Galaxy Australia's institution validation API.
+
+    Returns True/False for a definitive answer from the upstream service, or
+    None when the result could not be determined (network/parse error). Callers
+    that must not act on an outage should treat None distinctly from False.
+    """
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            response = await client.get(GALAXY_AU_VALIDATE_URL, params={"email": email})
+            response.raise_for_status()
+            return bool(response.json().get("valid", False))
+    except Exception:
+        return None
 
 
 async def is_australian_research_institution_email(email: str) -> bool:
@@ -9,10 +27,4 @@ async def is_australian_research_institution_email(email: str) -> bool:
     Returns False on any network or parse error so registration is never
     blocked by an upstream outage.
     """
-    try:
-        async with httpx.AsyncClient(timeout=5.0) as client:
-            response = await client.get(GALAXY_AU_VALIDATE_URL, params={"email": email})
-            response.raise_for_status()
-            return response.json().get("valid", False)
-    except Exception:
-        return False
+    return await check_australian_research_institution_email(email) is True

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1,7 +1,7 @@
 import hashlib
 from datetime import datetime, timedelta, timezone
 from http import HTTPStatus
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 import respx
@@ -1062,6 +1062,137 @@ def test_email_continue_updates_user(test_client, test_db_session, mocker, persi
         )
     ).one_or_none()
     assert remaining_active is None
+
+
+def _setup_email_change_with_sbp(
+    test_db_session,
+    mocker,
+    mock_auth0_client,
+    *,
+    new_email: str = "new@example.com",
+):
+    """
+    Shared setup for the SBP-revocation-on-email-change tests: a user holding an
+    approved SBP bundle, a pending OTP for a new email, and Auth0 mocks. Returns
+    (user, sbp_membership, code).
+    """
+    user = BiocommonsUserFactory.create_sync(email="old@institution.edu.au", email_verified=True)
+    sbp_group = BiocommonsGroupFactory.create_sync(
+        group_id=GroupEnum.SBP.value,
+        name="Structural Biology Platform Bundle",
+        short_name="SBP",
+    )
+    sbp_membership = GroupMembershipFactory.create_sync(
+        user=user,
+        group=sbp_group,
+        group_id=sbp_group.group_id,
+        approval_status=ApprovalStatusEnum.APPROVED,
+    )
+    test_db_session.flush()
+    _act_as_user(mocker, user)
+
+    code = "123456"
+    hashed = hashlib.sha256(code.encode()).hexdigest()
+    now = datetime.now(timezone.utc)
+    otp_entry = EmailChangeOtp(
+        user_id=user.id,
+        target_email=new_email,
+        otp_hash=hashed,
+        created_at=now,
+        expires_at=now + timedelta(minutes=10),
+        window_start=now,
+    )
+    test_db_session.add(otp_entry)
+    test_db_session.commit()
+
+    updated_user = Auth0UserDataFactory.build(
+        sub=user.id,
+        email=new_email,
+        email_verified=True,
+        app_metadata=BiocommonsAppMetadata(registration_from="biocommons"),
+    )
+    mock_auth0_client.update_user.return_value = updated_user
+    mock_auth0_client.get_role_by_name.return_value = MagicMock(id="role_sbp")
+    return user, sbp_membership, code
+
+
+def test_email_continue_revokes_sbp_for_non_institutional_email(
+    test_client, test_db_session, mocker, persistent_factories, mock_auth0_client
+):
+    user, sbp_membership, code = _setup_email_change_with_sbp(
+        test_db_session, mocker, mock_auth0_client
+    )
+    institution_check = mocker.patch(
+        "routers.user.check_australian_research_institution_email",
+        new=AsyncMock(return_value=False),
+    )
+
+    response = test_client.post(
+        "/me/profile/email/continue",
+        headers={"Authorization": "Bearer valid_token"},
+        json={"otp": code},
+    )
+
+    assert response.status_code == 200
+    institution_check.assert_awaited_once_with("new@example.com")
+
+    test_db_session.refresh(sbp_membership)
+    assert sbp_membership.approval_status == ApprovalStatusEnum.REVOKED
+    assert sbp_membership.revocation_reason == (
+        "Email changed to a non-Australian institutional address."
+    )
+    # Backing Auth0 role removed
+    mock_auth0_client.get_role_by_name.assert_called_once_with(GroupEnum.SBP.value)
+    mock_auth0_client.remove_roles_from_user.assert_called_once_with(
+        user_id=user.id, role_id="role_sbp"
+    )
+
+
+def test_email_continue_keeps_sbp_for_institutional_email(
+    test_client, test_db_session, mocker, persistent_factories, mock_auth0_client
+):
+    _, sbp_membership, code = _setup_email_change_with_sbp(
+        test_db_session, mocker, mock_auth0_client
+    )
+    mocker.patch(
+        "routers.user.check_australian_research_institution_email",
+        new=AsyncMock(return_value=True),
+    )
+
+    response = test_client.post(
+        "/me/profile/email/continue",
+        headers={"Authorization": "Bearer valid_token"},
+        json={"otp": code},
+    )
+
+    assert response.status_code == 200
+    test_db_session.refresh(sbp_membership)
+    assert sbp_membership.approval_status == ApprovalStatusEnum.APPROVED
+    mock_auth0_client.remove_roles_from_user.assert_not_called()
+
+
+def test_email_continue_keeps_sbp_when_institution_check_indeterminate(
+    test_client, test_db_session, mocker, persistent_factories, mock_auth0_client
+):
+    """An upstream outage (None) must not strip a user's existing SBP access."""
+    _, sbp_membership, code = _setup_email_change_with_sbp(
+        test_db_session, mocker, mock_auth0_client
+    )
+    mocker.patch(
+        "routers.user.check_australian_research_institution_email",
+        new=AsyncMock(return_value=None),
+    )
+
+    response = test_client.post(
+        "/me/profile/email/continue",
+        headers={"Authorization": "Bearer valid_token"},
+        json={"otp": code},
+    )
+
+    assert response.status_code == 200
+    test_db_session.refresh(sbp_membership)
+    assert sbp_membership.approval_status == ApprovalStatusEnum.APPROVED
+    mock_auth0_client.remove_roles_from_user.assert_not_called()
 
 
 def _make_auth0_identity(connection: str, user_id: str) -> Auth0Identity:

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1141,6 +1141,8 @@ def test_email_continue_revokes_sbp_for_non_institutional_email(
     assert sbp_membership.revocation_reason == (
         "Email changed to a non-Australian institutional address."
     )
+    # Recorded as an automatic change, not a self-revocation by the user
+    assert sbp_membership.updated_by is None
     # Backing Auth0 role removed
     mock_auth0_client.get_role_by_name.assert_called_once_with(GroupEnum.SBP.value)
     mock_auth0_client.remove_roles_from_user.assert_called_once_with(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -187,13 +187,12 @@ def test_check_australian_research_institution_invalid(test_client):
 
 
 @respx.mock
-def test_check_australian_research_institution_biocommons_override(test_client):
+def test_check_australian_research_institution_biocommons(test_client):
     """
-    Test that emails from biocommons.org.au are considered Australian research institutions
-    (either through override or upstream validation)
+    biocommons.org.au is included in Galaxy's institution list, so it is
+    validated upstream without any local override.
     """
-    # Assume Galaxy returns False - rely on override for now
-    respx.get(GALAXY_AU_VALIDATE_URL).mock(return_value=Response(200, json={"valid": False}))
+    respx.get(GALAXY_AU_VALIDATE_URL).mock(return_value=Response(200, json={"valid": True}))
     resp = test_client.get(
         "/utils/register/check-australian-research-institution",
         params={"email": "user@biocommons.org.au"},


### PR DESCRIPTION
## Description

[SBP-398](https://biocloud.atlassian.net/browse/SBP-398): Auto-revoke SBP bundle when a user changes to a non-institutional email

## Changes

- On email-change confirmation (`POST /me/profile/email/continue`), if the user holds an approved SBP bundle and the new email is non-institutional, automatically revoke the bundle and its backing Auth0 role (via existing `GroupMembership.revoke()`).
- Adds tri-state `check_australian_research_institution_email()` returning True/False/None; revocation only fires on a definitive non-institutional result — an indeterminate result (e.g. upstream outage) is logged and left untouched, so a transient failure never wrongly strips access.
- Existing `is_australian_research_institution_email()` now delegates to the tri-state helper; its False-on-error contract (used by registration/request gates) is unchanged.
- Remove `biocommons.org.au` that was whitelisted in the Australian Institutional list previously - now its added

Related front end changes: https://github.com/AustralianBioCommons/aai-portal/pull/244

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit / integration tests that prove my fix is effective or that my feature works
- [x] I have run all tests locally and they pass
- [x] I have updated the documentation (if applicable)
- [ ] For any new secrets, I have updated the [shared spreadsheet](https://docs.google.com/spreadsheets/d/16lGloFh4VxMmu6cJdeFVLy2654hdq-ZeErhB8UifSfI/edit?usp=sharing) and the [GitHub Secrets](https://github.com/AustralianBioCommons/aai-backend/settings/secrets/actions).

## How to Test Manually (if necessary)


`uv run pytest`

[SBP-398]: https://biocloud.atlassian.net/browse/SBP-398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ