### PR TITLE
feat: include admin user at the top of the user list (AAI-834)

### DIFF
--- a/routers/admin.py
+++ b/routers/admin.py
@@ -16,7 +16,7 @@ from pydantic import (
     ValidationError,
     field_validator,
 )
-from sqlalchemy import exists, func, or_
+from sqlalchemy import case, exists, func, or_
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import selectinload
 from sqlmodel import Session, select
@@ -446,37 +446,48 @@ class UserQueryParams(BaseModel):
     def _platform_scope_handled_by_permissions(self) -> bool:
         return self._is_platform_scoped_query() and not self._is_group_scoped_query()
 
+    def get_user_ordering(current_user_id: str | None = None):
+        """
+        Deterministic ordering for user lists (keeps pagination stable):
+        the current admin's own entry first, then by creation date.
+        """
+        ordering = []
+        if current_user_id is not None:
+            ordering.append(case((BiocommonsUser.id == current_user_id, 0), else_=1))
+        ordering.extend([BiocommonsUser.created_at, BiocommonsUser.id])
+        return ordering
+
     def _get_combined_query(
         self,
         admin_roles: list[str],
-        exclude_user_id: str | None = None,
+        current_user_id: str | None = None,
     ):
         """
         Combine admin permissions and queries from the params to get the overall
         user query
         """
         self._set_allowed_resource_subqueries(admin_roles)
-        query = (
+        return (
             self.get_base_query(include_memberships=True)
             .where(
                 self.get_admin_permissions_query(admin_roles),
                 *self.get_query_conditions(admin_roles))
+            .order_by(*self.get_user_ordering(current_user_id))
         )
-        if exclude_user_id:
-            query = query.where(BiocommonsUser.id != exclude_user_id)
-        return query
 
     def get_complete_query(
         self,
         admin_roles: list[str],
         pagination: PaginationParams = None,
-        exclude_user_id: str | None = None,
+        current_user_id: str | None = None,
     ) -> SelectOfScalar[BiocommonsUser]:
         """
-        Return a full user query, with permissions from admin roles and pagination applied
+        Return a full user query, with permissions from admin roles and pagination applied.
+        The current admin's own user entry (when it matches the query) is sorted to the
+        top of the results when current_user_id is provided.
         """
         return (
-            self._get_combined_query(admin_roles, exclude_user_id=exclude_user_id)
+            self._get_combined_query(admin_roles, current_user_id=current_user_id)
             .offset(pagination.start_index)
             .limit(pagination.per_page)
         )
@@ -612,18 +623,17 @@ class UserQueryParams(BaseModel):
         self,
         db_session: Session,
         admin_roles: list[str],
-        exclude_user_id: str | None = None,
     ) -> int:
         """
         Count distinct users matching the current filters and admin permissions.
+        Includes the current admin's own user entry when it matches, consistent
+        with get_complete_query.
         """
         self._set_allowed_resource_subqueries(admin_roles)
         count_statement = select(func.count(BiocommonsUser.id)).where(
             self.get_admin_permissions_query(admin_roles),
             *self.get_query_conditions(admin_roles)
         )
-        if exclude_user_id is not None:
-            count_statement = count_statement.where(BiocommonsUser.id != exclude_user_id)
         return db_session.exec(count_statement).one()
 
     def email_verified_query(self):
@@ -680,12 +690,13 @@ def get_filtered_user_query(
     """
     Get an SQLAlchemy query for users based on the provided filter parameters,
     filtered to only return users the admin has permission to view/manage.
+    The admin's own user entry is included and sorted to the top of the list.
     """
     admin_roles = admin_user.access_token.biocommons_roles
     return user_query.get_complete_query(
         admin_roles,
         pagination,
-        exclude_user_id=admin_user.access_token.sub,
+        current_user_id=admin_user.access_token.sub,
     )
 
 
@@ -735,7 +746,6 @@ def get_users_page_info(db_session: Annotated[Session, Depends(get_db_session)],
     total = query_params.get_count(
         db_session=db_session,
         admin_roles=admin_roles,
-        exclude_user_id=admin_user.access_token.sub,
     )
     return UsersPageInfoResponse(total=total, pages=math.ceil(total / pagination.per_page), per_page=pagination.per_page)
 
@@ -770,7 +780,6 @@ def get_user_counts(
         return params.get_count(
             db_session=db_session,
             admin_roles=admin_roles,
-            exclude_user_id=admin_user.access_token.sub,
         )
 
     revoked_overrides: dict[str, object] = {

--- a/routers/admin.py
+++ b/routers/admin.py
@@ -446,7 +446,7 @@ class UserQueryParams(BaseModel):
     def _platform_scope_handled_by_permissions(self) -> bool:
         return self._is_platform_scoped_query() and not self._is_group_scoped_query()
 
-    def get_user_ordering(current_user_id: str | None = None):
+    def get_user_ordering(self, current_user_id: str | None = None):
         """
         Deterministic ordering for user lists (keeps pagination stable):
         the current admin's own entry first, then by creation date.

--- a/tests/admin_api/test_admin.py
+++ b/tests/admin_api/test_admin.py
@@ -1,4 +1,5 @@
 import asyncio
+from datetime import datetime, timezone
 from urllib.parse import quote
 
 import pytest
@@ -171,13 +172,17 @@ def test_get_users(test_client, as_admin_user, galaxy_platform,
     assert all(u.id not in user_ids for u in invalid_users)
 
 
-def test_get_users_excludes_current_admin_user(
+def test_get_users_includes_current_admin_user_first(
     test_client,
     as_admin_user,
     galaxy_platform,
     test_db_session,
     persistent_factories,
 ):
+    """
+    The current admin's own user entry should be included in the user list,
+    sorted to the top.
+    """
     admin_db_user = as_admin_user
     membership = PlatformMembershipFactory.create_sync(
         user_id=admin_db_user.id,
@@ -188,6 +193,38 @@ def test_get_users_excludes_current_admin_user(
     test_db_session.add(admin_db_user)
     test_db_session.commit()
 
+    # Create users out of date order to check the list is sorted by created_at
+    # after the admin user
+    other_users = [
+        _create_user_with_platform_membership(
+            db_session=test_db_session,
+            platform_id=galaxy_platform.id,
+            approval_status=ApprovalStatusEnum.APPROVED,
+            created_at=datetime(2024, 1, day, tzinfo=timezone.utc),
+        )
+        for day in (3, 1, 2)
+    ]
+
+    resp = test_client.get("/admin/users")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 4
+    assert data[0]["id"] == admin_db_user.id
+    expected_order_after_admin = [other_users[1].id, other_users[2].id, other_users[0].id]
+    assert [u["id"] for u in data[1:]] == expected_order_after_admin
+
+
+def test_get_users_admin_without_matching_memberships_not_included(
+    test_client,
+    as_admin_user,
+    galaxy_platform,
+    test_db_session,
+    persistent_factories,
+):
+    """
+    The current admin only appears in the list if they match the query like any
+    other user (the admin fixture has no platform/group memberships here).
+    """
     other_user = _create_user_with_platform_membership(
         db_session=test_db_session,
         platform_id=galaxy_platform.id,
@@ -943,7 +980,7 @@ def test_get_user_page_info(
     }
 
 
-def test_get_user_page_info_excludes_current_admin_user(
+def test_get_user_page_info_includes_current_admin_user(
     test_client,
     as_admin_user,
     galaxy_platform,
@@ -951,6 +988,10 @@ def test_get_user_page_info_excludes_current_admin_user(
     test_db_session,
     persistent_factories,
 ):
+    """
+    Page info counts should include the current admin's own user entry when it
+    matches the query, consistent with the user list.
+    """
     admin_db_user = as_admin_user
     admin_membership = PlatformMembershipFactory.create_sync(
         user_id=admin_db_user.id,
@@ -978,10 +1019,11 @@ def test_get_user_page_info_excludes_current_admin_user(
     test_db_session.add(admin_db_user)
     test_db_session.commit()
 
+    # 2 approved + 3 pending + the admin user (approved on Galaxy)
     resp = test_client.get("/admin/users/pages")
     assert resp.status_code == 200
     assert resp.json() == {
-        "total": 5,
+        "total": 6,
         "pages": 1,
         "per_page": 100,
     }
@@ -989,7 +1031,7 @@ def test_get_user_page_info_excludes_current_admin_user(
     resp = test_client.get("/admin/users/pages?per_page=2")
     assert resp.status_code == 200
     assert resp.json() == {
-        "total": 5,
+        "total": 6,
         "pages": 3,
         "per_page": 2,
     }
@@ -999,7 +1041,7 @@ def test_get_user_page_info_excludes_current_admin_user(
     )
     assert resp.status_code == 200
     assert resp.json() == {
-        "total": 2,
+        "total": 3,
         "pages": 1,
         "per_page": 100,
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -274,6 +274,7 @@ def admin_user():
 def admin_db_user(admin_user, test_db_session, persistent_factories):
     admin_user = BiocommonsUserFactory.create_sync(
         id=admin_user.access_token.sub,
+        email_verified=True,
         group_memberships=[],
         platform_memberships=[],
     )


### PR DESCRIPTION
## Description

[AAI-834](https://biocloud.atlassian.net/jira/software/c/projects/AAI/boards/53?assignee=unassigned&assignee=63f30233526117e1514b222b&selectedIssue=AAI-834): Include admin user at the top of the user list

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit / integration tests that prove my fix is effective or that my feature works
- [x] I have run all tests locally and they pass
- [ ] I have updated the documentation (if applicable)
- [ ] For any new secrets, I have updated the [shared spreadsheet](https://docs.google.com/spreadsheets/d/16lGloFh4VxMmu6cJdeFVLy2654hdq-ZeErhB8UifSfI/edit?usp=sharing) and the [GitHub Secrets](https://github.com/AustralianBioCommons/aai-backend/settings/secrets/actions).


[AAI-834]: https://biocloud.atlassian.net/browse/AAI-834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ