### PR TITLE
feat: split sbp admin

### DIFF
--- a/scheduled_tasks/tasks.py
+++ b/scheduled_tasks/tasks.py
@@ -624,21 +624,15 @@ async def sync_auth0_roles():
             db_session.close()
 
 
-# Platforms whose admin role also grants admin access to an associated bundle group.
-# Key: PlatformEnum value, Value: full group_id of the associated bundle.
-PLATFORM_BUNDLE_GROUP_MAP: dict[PlatformEnum, str] = {
-    PlatformEnum.SBP: GroupEnum.SBP.value,
-}
-
-
 def link_admin_roles(session: Session, db_roles_by_name: dict[str, Auth0Role]) -> None:
     """
     Link admin roles to platforms/groups based on naming conventions:
       - Platform admin roles: biocommons/role/{platform_id}/admin
       - Group admin roles:    biocommons/role/{group_short_id}/admin where group_id is biocommons/group/{group_short_id}
 
-    For platforms listed in PLATFORM_BUNDLE_GROUP_MAP the platform admin role is
-    also linked to the associated bundle group so a single Auth0 role covers both.
+    Each admin role is linked to a single resource. SBP is split into a service
+    admin role (biocommons/role/sbp/admin -> SBP platform) and a bundle admin role
+    (biocommons/role/sbp_workflow_execution/admin -> SBP bundle group).
     """
     platform_admin_pattern = re.compile(
         r"^biocommons/role/(?P<platform_id>[a-z0-9_]+)/admin$", re.IGNORECASE
@@ -661,12 +655,6 @@ def link_admin_roles(session: Session, db_roles_by_name: dict[str, Auth0Role]) -
                 if role not in platform.admin_roles:
                     platform.admin_roles.append(role)
                     session.add(platform)
-                bundle_group_id = PLATFORM_BUNDLE_GROUP_MAP.get(platform_enum)
-                if bundle_group_id:
-                    group = BiocommonsGroup.get_by_id(bundle_group_id, session)
-                    if group and role not in group.admin_roles:
-                        group.admin_roles.append(role)
-                        session.add(group)
                 continue
 
         group_match = group_admin_pattern.match(role_name)

--- a/tests/scheduled_tasks/test_tasks.py
+++ b/tests/scheduled_tasks/test_tasks.py
@@ -326,11 +326,12 @@ def test_link_admin_roles_links_platform_and_group(test_db_session):
     assert group_role in group.admin_roles
 
 
-def test_link_admin_roles_platform_role_also_links_bundle_group(test_db_session):
-    """biocommons/role/sbp/admin should be linked to both the SBP platform and
-    the SBP bundle group via PLATFORM_BUNDLE_GROUP_MAP."""
+def test_link_admin_roles_splits_sbp_service_and_bundle(test_db_session):
+    """SBP has two separate admin roles: the service admin role
+    (biocommons/role/sbp/admin) links only to the SBP platform, and the bundle
+    admin role (biocommons/role/sbp_workflow_execution/admin) links only to the
+    SBP bundle group."""
     from db.types import GroupEnum
-    from scheduled_tasks.tasks import PLATFORM_BUNDLE_GROUP_MAP
 
     platform = PlatformFactory.build(id=PlatformEnum.SBP)
     group = BiocommonsGroupFactory.build(group_id=GroupEnum.SBP.value)
@@ -338,19 +339,32 @@ def test_link_admin_roles_platform_role_also_links_bundle_group(test_db_session)
     test_db_session.add(group)
     test_db_session.commit()
 
-    sbp_admin_role = Auth0RoleFactory.build(name="biocommons/role/sbp/admin")
-    test_db_session.add(sbp_admin_role)
+    service_admin_role = Auth0RoleFactory.build(name="biocommons/role/sbp/admin")
+    bundle_admin_role = Auth0RoleFactory.build(
+        name="biocommons/role/sbp_workflow_execution/admin"
+    )
+    test_db_session.add(service_admin_role)
+    test_db_session.add(bundle_admin_role)
     test_db_session.flush()
 
-    link_admin_roles(test_db_session, {sbp_admin_role.name: sbp_admin_role})
+    link_admin_roles(
+        test_db_session,
+        {
+            service_admin_role.name: service_admin_role,
+            bundle_admin_role.name: bundle_admin_role,
+        },
+    )
     test_db_session.commit()
 
     platform = Platform.get_by_id(PlatformEnum.SBP, test_db_session)
     group = BiocommonsGroup.get_by_id(GroupEnum.SBP.value, test_db_session)
 
-    assert sbp_admin_role in platform.admin_roles
-    assert sbp_admin_role in group.admin_roles
-    assert PlatformEnum.SBP in PLATFORM_BUNDLE_GROUP_MAP
+    # Service admin role gates the platform only
+    assert service_admin_role in platform.admin_roles
+    assert service_admin_role not in group.admin_roles
+    # Bundle admin role gates the bundle group only
+    assert bundle_admin_role in group.admin_roles
+    assert bundle_admin_role not in platform.admin_roles
 
 
 def test_link_admin_roles_case_insensitive(test_db_session):


### PR DESCRIPTION
## Description

[AAI-856](https://biocloud.atlassian.net/browse/AAI-856): Split SBP admin into platform and bundle

## Changes

-  removed `PLATFORM_BUNDLE_GROUP_MAP` and the branch that double-linked the SBP platform role to the bundle group. Now `link_admin_roles` links each role to exactly one resource. 
    - The new bundle role auto-links to `biocommons/group/sbp_workflow_execution` via the existing group-admin naming regex

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit / integration tests that prove my fix is effective or that my feature works
- [x] I have run all tests locally and they pass
- [x] I have updated the documentation (if applicable)
- [ ] For any new secrets, I have updated the [shared spreadsheet](https://docs.google.com/spreadsheets/d/16lGloFh4VxMmu6cJdeFVLy2654hdq-ZeErhB8UifSfI/edit?usp=sharing) and the [GitHub Secrets](https://github.com/AustralianBioCommons/aai-backend/settings/secrets/actions).

## How to Test Manually (if necessary)

```
uv run pytest
```

[AAI-856]: https://biocloud.atlassian.net/browse/AAI-856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ