### PR TITLE
fix: disable SBP for prod (AAI-830)

### DIFF
--- a/biocommons/default.py
+++ b/biocommons/default.py
@@ -7,3 +7,9 @@ DEFAULT_PLATFORMS: list[PlatformEnum] = [
     PlatformEnum.GALAXY,
     PlatformEnum.SBP,
 ]
+
+
+def get_default_platforms(*, sbp_enabled: bool = True) -> list[PlatformEnum]:
+    if sbp_enabled:
+        return list(DEFAULT_PLATFORMS)
+    return [platform for platform in DEFAULT_PLATFORMS if platform != PlatformEnum.SBP]

--- a/config.py
+++ b/config.py
@@ -21,6 +21,7 @@ class Settings(BaseSettings):
     auth0_algorithms: list[str] = ["RS256"]
     admin_roles: list[str] = []
     enable_admin_dashboard: bool = False
+    sbp_enabled: bool = False
     # Note we process this separately in app startup as it needs
     #   to be available before the app starts
     cors_allowed_origins: str

--- a/routers/admin.py
+++ b/routers/admin.py
@@ -290,7 +290,7 @@ def _revoke_group_membership(
 
 
 @router.get("/filters")
-def get_filter_options():
+def get_filter_options(settings: Annotated[Settings, Depends(get_settings)]):
     """
     Get available filter options for users endpoint.
 
@@ -300,12 +300,16 @@ def get_filter_options():
     options = []
 
     for platform_id, platform_data in PLATFORM_MAPPING.items():
+        if platform_id == "sbp" and not settings.sbp_enabled:
+            continue
         options.append({
             "id": platform_id,
             "name": platform_data["name"]
         })
 
     for group_id, group_data in GROUP_MAPPING.items():
+        if group_id == "sbp_workflow_execution" and not settings.sbp_enabled:
+            continue
         options.append({
             "id": group_id,
             "name": group_data["name"]

--- a/routers/biocommons_register.py
+++ b/routers/biocommons_register.py
@@ -7,7 +7,7 @@ from sqlmodel import Session
 
 from auth0.client import Auth0Client, get_auth0_client
 from biocommons.bundles import BUNDLES, BiocommonsBundle
-from biocommons.default import DEFAULT_PLATFORMS
+from biocommons.default import get_default_platforms
 from biocommons.emails import (
     compose_bundle_request_confirmation_email,
     compose_group_approval_email,
@@ -45,11 +45,12 @@ def create_user_in_db(user_data: Auth0UserData,
                       bundles: Optional[list[BundleRequest]],
                       session: Session,
                       auth0_client: Auth0Client,
-                      commit: bool = False) -> BiocommonsUser:
+                      commit: bool = False,
+                      sbp_enabled: bool = True) -> BiocommonsUser:
     db_user = BiocommonsUser.from_auth0_data(data=user_data)
     session.add(db_user)
     session.flush()
-    for platform in DEFAULT_PLATFORMS:
+    for platform in get_default_platforms(sbp_enabled=sbp_enabled):
         db_user.add_platform_membership(
             platform=platform,
             db_session=session,
@@ -204,6 +205,12 @@ async def check_sbp_email_domain(registration: BiocommonsRegistrationRequest) ->
             return is_institute
     return True
 
+
+def _requests_sbp_bundle(registration: BiocommonsRegistrationRequest) -> bool:
+    if registration.bundles is None:
+        return False
+    return any(bundle.bundle_id == "sbp_workflow_execution" for bundle in registration.bundles)
+
 @router.post(
     "/register",
     responses={
@@ -227,6 +234,10 @@ async def register_biocommons_user(
     if not recaptcha_check:
         response.status_code = 400
         return RegistrationErrorResponse(message="Invalid recaptcha token, please try again")
+
+    if _requests_sbp_bundle(registration) and not settings.sbp_enabled:
+        response.status_code = 400
+        return RegistrationErrorResponse(message="SBP workflow execution is currently unavailable.")
 
     # Pre-registration checks
     email_ok = await check_sbp_email_domain(registration)
@@ -265,6 +276,7 @@ async def register_biocommons_user(
             bundles=registration.bundles,
             session=db_session,
             auth0_client=auth0_client,
+            sbp_enabled=settings.sbp_enabled,
         )
 
         if registration.bundles is not None:

--- a/routers/user.py
+++ b/routers/user.py
@@ -506,6 +506,12 @@ def request_group_access(
     """
     has_sbp_request = any(item.group_id == GroupEnum.SBP.value for item in request_data.groups)
     if has_sbp_request:
+        if not settings.sbp_enabled:
+            raise HTTPException(
+                status_code=http.HTTPStatus.FORBIDDEN,
+                detail="SBP Workflow Execution bundle is currently unavailable.",
+            )
+
         is_institution = asyncio.run(is_australian_research_institution_email(db_user.email))
 
         if not is_institution:

--- a/scheduled_tasks/tasks.py
+++ b/scheduled_tasks/tasks.py
@@ -760,6 +760,8 @@ async def sync_group_user_roles():
     with Auth0Client(domain=settings.auth0_domain, management_token=token) as auth0_client:
         roles = [role for role in auth0_client.get_all_roles()
                  if re.match(GROUP_ROLE_PATTERN, role.name)]
+        if not settings.sbp_enabled:
+            roles = [role for role in roles if role.name != GroupEnum.SBP.value]
         for role in roles:
             db_session = next(get_db_session())
             try:
@@ -874,6 +876,11 @@ async def sync_platform_user_roles():
         exported_users_by_id = {user.user_id: user for user in exported_users}
         roles = [role for role in auth0_client.get_all_roles()
                  if re.match(PLATFORM_ROLE_PATTERN, role.name)]
+        if not settings.sbp_enabled:
+            roles = [
+                role for role in roles
+                if get_platform_id_from_role_name(role.name) != PlatformEnum.SBP.value
+            ]
         for role in roles:
             db_session = next(get_db_session())
             try:

--- a/tests/admin_api/test_admin.py
+++ b/tests/admin_api/test_admin.py
@@ -497,13 +497,13 @@ def test_get_users_search_with_filter(test_client, as_admin_user, galaxy_platfor
     assert len(results) == 0
 
 
-def test_get_filter_options(test_client, as_admin_user, test_db_session, persistent_factories):
+def test_get_filter_options_excludes_sbp_when_disabled(test_client, as_admin_user, test_db_session, persistent_factories):
     resp = test_client.get("/admin/filters")
     assert resp.status_code == 200
 
     options = resp.json()
     assert isinstance(options, list)
-    assert len(options) == 5
+    assert len(options) == 3
 
     for option in options:
         assert "id" in option
@@ -512,15 +512,37 @@ def test_get_filter_options(test_client, as_admin_user, test_db_session, persist
         assert isinstance(option["name"], str)
 
     option_ids = {opt["id"] for opt in options}
-    expected_ids = {"galaxy", "bpa_data_portal", "sbp", "tsi", "sbp_workflow_execution"}
+    expected_ids = {"galaxy", "bpa_data_portal", "tsi"}
     assert option_ids == expected_ids
 
     option_dict = {opt["id"]: opt["name"] for opt in options}
     assert option_dict["galaxy"] == "Galaxy Australia"
     assert option_dict["bpa_data_portal"] == "Bioplatforms Australia Data Portal"
+    assert option_dict["tsi"] == "Threatened Species Initiative"
+
+
+def test_get_filter_options_includes_sbp_when_enabled(
+    test_client,
+    mock_settings,
+    as_admin_user,
+    test_db_session,
+    persistent_factories,
+):
+    mock_settings.sbp_enabled = True
+
+    resp = test_client.get("/admin/filters")
+    assert resp.status_code == 200
+
+    options = resp.json()
+    assert len(options) == 5
+
+    option_ids = {opt["id"] for opt in options}
+    expected_ids = {"galaxy", "bpa_data_portal", "sbp", "tsi", "sbp_workflow_execution"}
+    assert option_ids == expected_ids
+
+    option_dict = {opt["id"]: opt["name"] for opt in options}
     assert option_dict["sbp"] == "Structural Biology Platform"
     assert option_dict["sbp_workflow_execution"] == "Structural Biology Platform Bundle"
-    assert option_dict["tsi"] == "Threatened Species Initiative"
 
 
 def test_get_user(test_client, test_db_session, as_admin_user, galaxy_platform, persistent_factories):

--- a/tests/scheduled_tasks/test_tasks.py
+++ b/tests/scheduled_tasks/test_tasks.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta, timezone
 from enum import Enum
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from botocore.exceptions import ClientError, EndpointConnectionError
@@ -20,7 +20,7 @@ from db.models import (
     PlatformMembership,
     PlatformMembershipHistory,
 )
-from db.types import ApprovalStatusEnum, EmailStatusEnum, PlatformEnum
+from db.types import ApprovalStatusEnum, EmailStatusEnum, GroupEnum, PlatformEnum
 from scheduled_tasks.email_retry import (
     EMAIL_MAX_ATTEMPTS,
     EMAIL_RETRY_WINDOW_SECONDS,
@@ -663,6 +663,33 @@ async def test_sync_auth0_group_roles_syncs_assignments(mocker, test_db_session,
 
 
 @pytest.mark.asyncio
+async def test_sync_auth0_group_roles_skips_sbp_when_disabled(mocker, test_db_session, mock_settings):
+    mock_settings.sbp_enabled = False
+    tsi_role = SimpleNamespace(id="role-tsi", name=GroupEnum.TSI.value, description="TSI")
+    sbp_role = SimpleNamespace(id="role-sbp", name=GroupEnum.SBP.value, description="SBP")
+
+    mock_auth0_client = MagicMock()
+    mock_auth0_client.get_all_roles.return_value = [tsi_role, sbp_role]
+    mock_auth0_client_cm = mocker.patch("scheduled_tasks.tasks.Auth0Client")
+    mock_auth0_client_cm.return_value.__enter__.return_value = mock_auth0_client
+    sync_role = mocker.patch(
+        "scheduled_tasks.tasks.sync_group_memberships_for_role",
+        new=AsyncMock(),
+    )
+    mocker.patch("scheduled_tasks.tasks.get_settings", return_value=mock_settings)
+    mocker.patch("scheduled_tasks.tasks.get_management_token", return_value="token")
+    mocker.patch(
+        "scheduled_tasks.tasks.get_db_session",
+        return_value=_task_session_iter(test_db_session.get_bind()),
+    )
+
+    await sync_group_user_roles()
+
+    sync_role.assert_awaited_once()
+    assert sync_role.await_args.args[0] is tsi_role
+
+
+@pytest.mark.asyncio
 async def test_populate_db_groups_only_adds_missing(test_db_session, mocker, mock_settings, persistent_factories):
     """
     Ensure existing groups are skipped and missing ones are inserted then committed.
@@ -819,6 +846,42 @@ async def test_sync_auth0_platform_roles(mocker, test_db_session, mock_settings,
     assert removed_membership.is_deleted is True
     assert created_user is not None
     assert len(history_entries) > len(history_before)
+
+
+@pytest.mark.asyncio
+async def test_sync_auth0_platform_roles_skips_sbp_when_disabled(mocker, test_db_session, mock_settings):
+    mock_settings.sbp_enabled = False
+    galaxy_role = SimpleNamespace(
+        id="role-galaxy",
+        name="biocommons/platform/galaxy",
+        description="Galaxy",
+    )
+    sbp_role = SimpleNamespace(
+        id="role-sbp",
+        name="biocommons/platform/sbp",
+        description="SBP",
+    )
+
+    mock_auth0_client = MagicMock()
+    mock_auth0_client.get_all_roles.return_value = [galaxy_role, sbp_role]
+    mock_auth0_client_cm = mocker.patch("scheduled_tasks.tasks.Auth0Client")
+    mock_auth0_client_cm.return_value.__enter__.return_value = mock_auth0_client
+    sync_role = mocker.patch(
+        "scheduled_tasks.tasks.sync_platform_memberships_for_role",
+        new=AsyncMock(),
+    )
+    mocker.patch("scheduled_tasks.tasks.get_settings", return_value=mock_settings)
+    mocker.patch("scheduled_tasks.tasks.get_management_token", return_value="token")
+    mocker.patch(
+        "scheduled_tasks.tasks.get_db_session",
+        return_value=_task_session_iter(test_db_session.get_bind()),
+    )
+    mocker.patch("scheduled_tasks.tasks.export_auth0_users", return_value=[])
+
+    await sync_platform_user_roles()
+
+    sync_role.assert_awaited_once()
+    assert sync_role.await_args.args[0] is galaxy_role
 
 
 @pytest.mark.asyncio

--- a/tests/test_biocommons_register.py
+++ b/tests/test_biocommons_register.py
@@ -7,7 +7,7 @@ from sqlmodel import select
 from starlette.exceptions import HTTPException
 
 from biocommons.bundles import BUNDLES
-from biocommons.default import DEFAULT_PLATFORMS
+from biocommons.default import get_default_platforms
 from db.models import BiocommonsUser, BiocommonsUserHistory, EmailNotification
 from db.types import ApprovalStatusEnum, EmailStatusEnum, GroupEnum, PlatformEnum
 from routers.biocommons_register import check_sbp_email_domain, create_user_in_db
@@ -369,6 +369,7 @@ def test_biocommons_registration_name_formatting():
 
 def test_successful_biocommons_registration_endpoint(
     test_client_with_email,
+    mock_settings,
     mock_auth0_client,
     tsi_group,
     galaxy_platform,
@@ -378,6 +379,7 @@ def test_successful_biocommons_registration_endpoint(
     mock_recaptcha_verify,
 ):
     """Test successful biocommons registration via HTTP endpoint"""
+    mock_settings.sbp_enabled = True
     auth0_data = Auth0UserDataFactory.build()
     mock_auth0_client.create_user.return_value = auth0_data
     admin_stub = RoleUserDataFactory.build(email="tsi.admin@example.com")
@@ -435,6 +437,7 @@ def test_successful_biocommons_registration_endpoint(
 
 def test_biocommons_registration_endpoint_multiple_bundles(
     test_client_with_email,
+    mock_settings,
     mock_auth0_client,
     tsi_group,
     sbp_group,
@@ -446,6 +449,7 @@ def test_biocommons_registration_endpoint_multiple_bundles(
     mocker,
 ):
     """Test BioCommons registration can request multiple bundles at once."""
+    mock_settings.sbp_enabled = True
     auth0_data = Auth0UserDataFactory.build(
         email="researcher@unimelb.edu.au",
         username="multi_bundle_user",
@@ -499,11 +503,13 @@ def test_biocommons_registration_endpoint_multiple_bundles(
 
 def test_biocommons_registration_endpoint_sbp_rejects_non_institutional_email(
     test_client,
+    mock_settings,
     mock_auth0_client,
     mock_recaptcha_verify,
     mocker,
 ):
     """Test SBP workflow registration checks the email domain before creating a user."""
+    mock_settings.sbp_enabled = True
     domain_check = mocker.patch(
         "routers.biocommons_register.is_australian_research_institution_email",
         new=AsyncMock(return_value=False),
@@ -532,6 +538,41 @@ def test_biocommons_registration_endpoint_sbp_rejects_non_institutional_email(
         ],
     }
     domain_check.assert_awaited_once_with("external@example.com")
+    assert mock_auth0_client.create_user.call_count == 0
+
+
+def test_biocommons_registration_endpoint_sbp_disabled_rejects_before_creating_user(
+    test_client,
+    mock_settings,
+    mock_auth0_client,
+    mock_recaptcha_verify,
+    mocker,
+):
+    """Test SBP workflow registration is blocked by the feature flag."""
+    mock_settings.sbp_enabled = False
+    domain_check = mocker.patch(
+        "routers.biocommons_register.is_australian_research_institution_email",
+        new=AsyncMock(return_value=True),
+    )
+
+    registration_data = {
+        "first_name": "SBP",
+        "last_name": "Disabled",
+        "email": "researcher@unimelb.edu.au",
+        "username": "sbp_disabled_user",
+        "password": "StrongPass1!",
+        "bundles": [{"bundle_id": "sbp_workflow_execution", "reason": "SBP access"}],
+        "recaptcha_token": "mock-token",
+    }
+
+    response = test_client.post("/biocommons/register", json=registration_data)
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "message": "SBP workflow execution is currently unavailable.",
+        "field_errors": [],
+    }
+    domain_check.assert_not_awaited()
     assert mock_auth0_client.create_user.call_count == 0
 
 
@@ -738,7 +779,7 @@ def test_biocommons_registration_missing_group_error(test_client, mock_auth0_cli
     assert response.json()["detail"] == "Internal server error"
 
 
-def test_registration_endpoint_no_bundle(test_db_session, test_client, galaxy_platform, bpa_platform, sbp_platform, mock_auth0_client, mock_recaptcha_verify,):
+def test_registration_endpoint_no_bundle(test_db_session, test_client, galaxy_platform, bpa_platform, mock_auth0_client, mock_recaptcha_verify,):
     """Test database record creation when no bundle is selected"""
     registration = BiocommonsRegistrationRequest(
         first_name="No",
@@ -767,9 +808,53 @@ def test_registration_endpoint_no_bundle(test_db_session, test_client, galaxy_pl
     assert user.email == registration.email
     assert user.id == auth0_data.user_id
 
-    assert len(user.platform_memberships) == len(DEFAULT_PLATFORMS)
+    default_platforms = get_default_platforms(sbp_enabled=False)
+    assert len(user.platform_memberships) == len(default_platforms)
     platform_ids = {pm.platform_id for pm in user.platform_memberships}
-    for platform in DEFAULT_PLATFORMS:
+    for platform in default_platforms:
         assert platform in platform_ids
+    assert PlatformEnum.SBP not in platform_ids
     for pm in user.platform_memberships:
         assert pm.approval_status.value == "approved"
+
+
+def test_registration_endpoint_no_bundle_sbp_disabled(
+    test_db_session,
+    test_client,
+    mock_settings,
+    galaxy_platform,
+    bpa_platform,
+    mock_auth0_client,
+    mock_recaptcha_verify,
+):
+    """Test default registration does not create SBP platform membership when disabled."""
+    mock_settings.sbp_enabled = False
+    registration = BiocommonsRegistrationRequest(
+        first_name="No",
+        last_name="SBP",
+        email="no.sbp@example.com",
+        username="no_sbp",
+        password="StrongPass1!",
+        bundles=None,
+        recaptcha_token="mock-token",
+    )
+
+    auth0_data = Auth0UserDataFactory.build(
+        email="no.sbp@example.com",
+        username="no_sbp",
+        name="No SBP",
+    )
+    mock_auth0_client.create_user.return_value = Auth0UserDataFactory.build(
+        user_id=auth0_data.user_id,
+        email=auth0_data.email,
+        username=auth0_data.username,
+    )
+
+    response = test_client.post("/biocommons/register", json=registration.model_dump(mode="json"))
+
+    assert response.status_code == 200
+    user = test_db_session.get(BiocommonsUser, auth0_data.user_id)
+    assert user is not None
+    platform_ids = {membership.platform_id for membership in user.platform_memberships}
+    assert platform_ids == set(get_default_platforms(sbp_enabled=False))
+    assert PlatformEnum.SBP not in platform_ids

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -55,6 +55,17 @@ def test_no_reply_email_sender_manual():
     assert settings.no_reply_email_sender == custom_email
 
 
+def test_sbp_enabled_defaults_false():
+    settings = Settings(_env_file=None, **_base_settings_kwargs())
+    assert settings.sbp_enabled is False
+
+
+def test_sbp_enabled_reads_env(monkeypatch):
+    monkeypatch.setenv("SBP_ENABLED", "true")
+    settings = Settings(_env_file=None, **_base_settings_kwargs())
+    assert settings.sbp_enabled is True
+
+
 def test_no_reply_email_sender_required():
     """
     Test that omitting the no-reply email sender raises a validation error.

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -416,12 +416,14 @@ def test_request_group_membership(test_client_with_email, normal_user, as_normal
 
 def test_request_group_membership_checks_email_for_sbp(
     test_client,
+    mock_settings,
     normal_user,
     as_normal_user,
     test_db_session,
     persistent_factories,
     mocker,
 ):
+    mock_settings.sbp_enabled = True
     group = BiocommonsGroupFactory.create_sync(group_id=GroupEnum.SBP.value)
     BiocommonsUserFactory.create_sync(
         group_memberships=[],
@@ -449,15 +451,54 @@ def test_request_group_membership_checks_email_for_sbp(
     assert membership is None
 
 
+def test_request_group_membership_blocks_sbp_when_disabled(
+    test_client,
+    mock_settings,
+    normal_user,
+    as_normal_user,
+    test_db_session,
+    persistent_factories,
+    mocker,
+):
+    mock_settings.sbp_enabled = False
+    group = BiocommonsGroupFactory.create_sync(group_id=GroupEnum.SBP.value)
+    BiocommonsUserFactory.create_sync(
+        group_memberships=[],
+        id=normal_user.access_token.sub,
+        email="user@biocommons.org.au",
+    )
+    institution_check = mocker.patch(
+        "routers.user.is_australian_research_institution_email",
+        new=AsyncMock(return_value=True),
+    )
+
+    resp = test_client.post(
+        "/me/groups/request",
+        json={"groups": [{"group_id": group.group_id, "request_reason": "Need SBP workflow access"}]},
+    )
+
+    assert resp.status_code == HTTPStatus.FORBIDDEN
+    assert resp.json()["detail"] == "SBP Workflow Execution bundle is currently unavailable."
+    institution_check.assert_not_awaited()
+    membership = GroupMembership.get_by_user_id_and_group_id(
+        user_id=normal_user.access_token.sub,
+        group_id=group.group_id,
+        session=test_db_session,
+    )
+    assert membership is None
+
+
 @pytest.mark.asyncio
 async def test_request_group_membership_allows_biocommons(
         test_client,
+        mock_settings,
         normal_user,
         as_normal_user,
         test_db_session,
         persistent_factories,
         mocker,
 ):
+    mock_settings.sbp_enabled = True
     group = BiocommonsGroupFactory.create_sync(group_id=GroupEnum.SBP.value)
     BiocommonsUserFactory.create_sync(
         group_memberships=[],
@@ -571,6 +612,7 @@ def test_request_group_membership_revoked_returns_conflict(
 
 def test_sbp_institution_check_blocks_multi_group_request(
     test_client,
+    mock_settings,
     normal_user,
     as_normal_user,
     test_db_session,
@@ -578,6 +620,7 @@ def test_sbp_institution_check_blocks_multi_group_request(
     mocker,
 ):
     """Institution check failure on SBP blocks the whole multi-group request, including TSI."""
+    mock_settings.sbp_enabled = True
     tsi_group = BiocommonsGroupFactory.create_sync(group_id=GroupEnum.TSI.value)
     BiocommonsGroupFactory.create_sync(group_id=GroupEnum.SBP.value)
     BiocommonsUserFactory.create_sync(group_memberships=[], id=normal_user.access_token.sub)
@@ -607,6 +650,7 @@ def test_sbp_institution_check_blocks_multi_group_request(
 @respx.mock
 def test_request_multiple_groups(
     test_client_with_email,
+    mock_settings,
     normal_user,
     as_normal_user,
     mock_auth0_client,
@@ -615,6 +659,7 @@ def test_request_multiple_groups(
     mocker,
 ):
     """Requesting two groups at once returns per-group results for both."""
+    mock_settings.sbp_enabled = True
     admin_role = Auth0RoleFactory.create_sync(name="biocommons/role/tsi/admin")
     tsi_group = BiocommonsGroupFactory.create_sync(group_id=GroupEnum.TSI.value, admin_roles=[admin_role])
     sbp_group = BiocommonsGroupFactory.create_sync(group_id=GroupEnum.SBP.value)
@@ -660,6 +705,7 @@ def test_request_multiple_groups(
 
 def test_request_multiple_groups_fails_all_on_error(
     test_client_with_email,
+    mock_settings,
     normal_user,
     as_normal_user,
     mock_auth0_client,
@@ -668,6 +714,7 @@ def test_request_multiple_groups_fails_all_on_error(
     mocker,
 ):
     """If any group in the request fails validation, the whole request errors and nothing is committed."""
+    mock_settings.sbp_enabled = True
     mocker.patch(
         "routers.user.is_australian_research_institution_email",
         new=AsyncMock(return_value=True),


### PR DESCRIPTION
## Description

[AAI-830](https://biocloud.atlassian.net/browse/AAI-830): want to do a production release, but without enabling SBP access. Gate SBP access behind a config flag (False by default, to ensure it's not accidentally enabled)


[AAI-830]: https://biocloud.atlassian.net/browse/AAI-830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ