### PR TITLE
chore: allow release-please to create releases from release branches

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,7 +2,9 @@ name: release-please-build-publish
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - release/**
   workflow_dispatch:
 
 jobs:
@@ -29,6 +31,7 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          target-branch: ${{ github.ref_name }}
 
   publish-release-image:
     name: Build And Push Backend Release Image


### PR DESCRIPTION
## Description

For small fixes, we may want to cherry pick them into the current release rather than doing a full release with multiple changes. Allow `release-please` to create releases when we push to `release/1.x` branches