### PR TITLE
feat: represent AAF users in aai-backend database (AAI-871) 

### DIFF
--- a/.github/workflows/check-migrations.yml
+++ b/.github/workflows/check-migrations.yml
@@ -4,8 +4,6 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
 
 jobs:
 

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
 
 jobs:
   test:

--- a/alembic.ini
+++ b/alembic.ini
@@ -12,6 +12,7 @@ script_location = migrations
 
 # sys.path path, will be prepended to sys.path if present.
 # defaults to the current working directory.
+path_separator = os
 prepend_sys_path = .
 
 # timezone to use when rendering the date within the migration file

--- a/auth/account_permissions.py
+++ b/auth/account_permissions.py
@@ -1,0 +1,66 @@
+from enum import StrEnum
+from logging import getLogger
+from typing import Annotated
+
+from fastapi import HTTPException
+from fastapi.params import Depends
+from starlette import status
+
+from auth.user_permissions import get_db_user
+from db.models import BiocommonsUser
+
+logger = getLogger("uvicorn.error")
+
+
+class AccountActions(StrEnum):
+    CHANGE_EMAIL = 'change_email'
+    CHANGE_PASSWORD = 'change_password'
+    CHANGE_USERNAME = 'change_username'
+    CHANGE_NAME = 'change_name'
+
+
+def account_action_allowed(action: AccountActions, user: BiocommonsUser) -> bool:
+    """
+    Check if a user can perform an action, based on account type.
+    """
+    # All actions currently allowed for Auth0 users
+    if user.account_type == "auth0":
+        return True
+    elif user.account_type == "aaf":
+        match action:
+            case AccountActions.CHANGE_EMAIL:
+                return False
+            case AccountActions.CHANGE_USERNAME:
+                # TODO: assuming usernames are specific to BiocommonsAccess,
+                #   so changes are still allowed.
+                return True
+            case AccountActions.CHANGE_PASSWORD:
+                return False
+            case AccountActions.CHANGE_NAME:
+                # TODO: Assuming we allow users to set their name and don't
+                #   auto-update from AAF
+                return True
+    logger.warning(f"Unexpected account type ({user.account_type})/action ({action}. Disallowing by default.")
+    return False
+
+
+def require_account_permission(action: AccountActions) -> Depends:
+    """
+    FastAPI dependency that checks if the user can perform an action, based on account type.
+    """
+    def require_account_action(
+        user: Annotated[BiocommonsUser | None, Depends(get_db_user)],
+    ) -> BiocommonsUser:
+        if user is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="User account not found.",
+            )
+        if not account_action_allowed(action, user):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="You do not have permission to perform this action.",
+            )
+        return user
+
+    return Depends(require_account_action)

--- a/auth/account_permissions.py
+++ b/auth/account_permissions.py
@@ -31,9 +31,9 @@ def account_action_allowed(action: AccountActions, user: BiocommonsUser) -> bool
             case AccountActions.CHANGE_EMAIL:
                 return False
             case AccountActions.CHANGE_USERNAME:
-                # TODO: assuming usernames are specific to BiocommonsAccess,
-                #   so changes are still allowed.
-                return True
+                # TODO: username change code currently assumes the
+                #   Auth0 DB connection, so disable for AAF for now
+                return False
             case AccountActions.CHANGE_PASSWORD:
                 return False
             case AccountActions.CHANGE_NAME:

--- a/auth0/client.py
+++ b/auth0/client.py
@@ -231,7 +231,12 @@ class Auth0Client:
             raise ValueError(f"Failed to update user {user_id}: {exc.response.json()}") from exc
         return Auth0UserData(**resp.json())
 
-    def start_user_export(self, format: str = "csv", fields: Optional[list[dict]] = None, ) -> str:
+    def start_user_export(
+        self,
+        format: str = "csv",
+        fields: Optional[list[dict]] = None,
+        connection_id: str | None = None,
+    ) -> str:
         """
         Start a user export job, return the job ID.
         """
@@ -242,7 +247,10 @@ class Auth0Client:
                 {"name": "email"},
                 {"name": "username"}
             ]
-        resp = self._client.post(url, json={"format": format, "fields": fields})
+        payload = {"format": format, "fields": fields}
+        if connection_id is not None:
+            payload["connection_id"] = connection_id
+        resp = self._client.post(url, json=payload)
         resp.raise_for_status()
         return resp.json()["id"]
 
@@ -252,13 +260,19 @@ class Auth0Client:
         resp.raise_for_status()
         return JobStatus(**resp.json())
 
-    def export_and_download_users(self, download_path: pathlib.Path, fields: Optional[list[dict]] = None, timeout: int = 300):
+    def export_and_download_users(
+        self,
+        download_path: pathlib.Path,
+        fields: Optional[list[dict]] = None,
+        timeout: int = 300,
+        connection_id: str | None = None,
+    ):
         """
         Export Auth0 users to a CSV file and download it.
 
         NOTE: the Auth0 export has some quirks, e.g. string fields are preceded by '.
         """
-        job_id = self.start_user_export(fields=fields)
+        job_id = self.start_user_export(fields=fields, connection_id=connection_id)
 
         location = None
         start_time = time.time()

--- a/auth0/client.py
+++ b/auth0/client.py
@@ -7,7 +7,7 @@ from typing import Iterator, Optional, Type, TypeVar
 import httpx
 from fastapi import Depends
 from httpx import HTTPStatusError
-from pydantic import BaseModel, EmailStr, HttpUrl, model_validator
+from pydantic import BaseModel, EmailStr, Field, HttpUrl, model_validator
 
 from auth.management import get_management_token
 from config import Settings, get_settings
@@ -19,6 +19,27 @@ from schemas.biocommons import (
 )
 
 logger = logging.getLogger("uvicorn.error")
+
+
+class Auth0Connection(BaseModel):
+    name: str
+    display_name: str | None = None
+    options: dict = Field(default_factory=dict)
+    id: str
+    strategy: str
+    realms: list[str]
+    is_domain_connection: bool
+    show_as_button: bool | None = None
+    metadata: dict[str, str] | None = None
+    authentication: dict[str, bool]
+    connected_accounts: dict[str, bool]
+    cross_app_access_requesting_app: dict[str, bool] | None = None
+    cross_app_access_resource_app: dict[str, str] | None = None
+
+
+class ConnectionsWithCheckpoint(BaseModel):
+    connections: list[Auth0Connection]
+    next: str | None = None
 
 
 class RoleData(BaseModel):
@@ -400,6 +421,23 @@ class Auth0Client:
             }
         )
         return self._convert_users(resp)
+
+    def get_connections(self) -> list[Auth0Connection]:
+        url = f"https://{self.domain}/api/v2/connections"
+        resp = self._client.get(url, params={"take": 10})
+        resp.raise_for_status()
+        converted = ConnectionsWithCheckpoint(**resp.json())
+        if converted.next is not None:
+            logger.warning("More connections than expected - not all will be returned")
+        return converted.connections
+
+    def get_connection_by_name(self, name: str) -> Auth0Connection | None:
+        connections = self.get_connections()
+        result = None
+        for connection in connections:
+            if connection.name == name:
+                result = connection
+        return result
 
     def get_roles(self,
                   name_filter: Optional[str] = None,

--- a/auth0/client.py
+++ b/auth0/client.py
@@ -13,7 +13,7 @@ from auth.management import get_management_token
 from config import Settings, get_settings
 from schemas.biocommons import (
     Auth0UserData,
-    BiocommonsAppMetadata,
+    BiocommonsAppMetadataUpdate,
     BiocommonsPassword,
     BiocommonsRegisterData,
 )
@@ -114,7 +114,7 @@ class UpdateUserData(BaseModel):
     """
     _connection_required_fields = ["email", "email_verified", "password", "username"]
     # NOTE: app_metadata will be merged instead of replaced when updating
-    app_metadata: Optional[BiocommonsAppMetadata] = None
+    app_metadata: Optional[BiocommonsAppMetadataUpdate] = None
     blocked: Optional[bool] = None
     email: Optional[EmailStr] = None
     email_verified: Optional[bool] = None

--- a/db/models.py
+++ b/db/models.py
@@ -175,7 +175,8 @@ class BiocommonsUser(SoftDeleteModel, table=True):
         """
         Create a new BiocommonsUser object from Auth0 user data (no API call).
         """
-        return cls(id=data.user_id, email=data.email, username=data.username, email_verified=data.email_verified)
+        return cls(id=data.user_id, email=data.email, username=data.username, email_verified=data.email_verified,
+                   account_type=data.app_metadata.account_type)
 
     @classmethod
     def get_or_create(

--- a/db/models.py
+++ b/db/models.py
@@ -1,7 +1,8 @@
 import uuid
 from datetime import datetime, timezone
+from enum import StrEnum
 from logging import getLogger
-from typing import Optional, Self
+from typing import Optional, Self, Type
 
 from httpx import HTTPStatusError
 from pydantic import AwareDatetime
@@ -21,10 +22,15 @@ from db.types import (
     PlatformMembershipData,
 )
 from schemas.auth0 import get_platform_id_from_role_name
+from schemas.biocommons import BiocommonsUserAccountType
 from schemas.tokens import AccessTokenPayload
 from schemas.user import SessionUser
 
 logger = getLogger(__name__)
+
+
+def get_enum_values(enum: Type[StrEnum]) -> list[str]:
+    return [e.value for e in enum]
 
 
 class BiocommonsUser(SoftDeleteModel, table=True):
@@ -34,6 +40,14 @@ class BiocommonsUser(SoftDeleteModel, table=True):
     )
     # Auth0 ID
     id: str = Field(primary_key=True)
+    account_type: BiocommonsUserAccountType = Field(
+        sa_type=DbEnum(
+            BiocommonsUserAccountType,
+            name="biocommons_user_account_type",
+            values_callable=get_enum_values,
+            validate_strings=True
+        )
+    )
     # Note: sqlmodel can't validate emails easily.
     #   Use a separate data model to validate this
     email: str = Field(unique=True)

--- a/migrations/versions/0c91366532ae_user_account_type.py
+++ b/migrations/versions/0c91366532ae_user_account_type.py
@@ -31,13 +31,13 @@ def upgrade() -> None:
         ),
     )
     op.execute("UPDATE biocommons_user SET account_type = 'auth0' WHERE account_type IS NULL")
-    op.alter_column(
-        'biocommons_user',
-        'account_type',
-        existing_type=account_type_enum,
-        nullable=False,
-        server_default=None,
-    )
+    with op.batch_alter_table('biocommons_user') as batch_op:
+        batch_op.alter_column(
+            'account_type',
+            existing_type=account_type_enum,
+            nullable=False,
+            server_default=None,
+        )
 
 
 def downgrade() -> None:

--- a/migrations/versions/0c91366532ae_user_account_type.py
+++ b/migrations/versions/0c91366532ae_user_account_type.py
@@ -21,6 +21,7 @@ depends_on: Union[str, Sequence[str], None] = None
 
 def upgrade() -> None:
     account_type_enum = sa.Enum('auth0', 'aaf', name='biocommons_user_account_type')
+    account_type_enum.create(op.get_bind(), checkfirst=True)
     op.add_column(
         'biocommons_user',
         sa.Column(
@@ -41,4 +42,6 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    account_type_enum = sa.Enum('auth0', 'aaf', name='biocommons_user_account_type')
     op.drop_column('biocommons_user', 'account_type')
+    account_type_enum.drop(op.get_bind(), checkfirst=True)

--- a/migrations/versions/0c91366532ae_user_account_type.py
+++ b/migrations/versions/0c91366532ae_user_account_type.py
@@ -1,0 +1,44 @@
+"""user_account_type
+
+Revision ID: 0c91366532ae
+Revises: 39caad32922e
+Create Date: 2026-08-06 14:12:14.614001
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel
+
+
+# revision identifiers, used by Alembic.
+revision: str = '0c91366532ae'
+down_revision: Union[str, None] = '39caad32922e'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    account_type_enum = sa.Enum('auth0', 'aaf', name='biocommons_user_account_type')
+    op.add_column(
+        'biocommons_user',
+        sa.Column(
+            'account_type',
+            account_type_enum,
+            nullable=True,
+            server_default='auth0',
+        ),
+    )
+    op.execute("UPDATE biocommons_user SET account_type = 'auth0' WHERE account_type IS NULL")
+    op.alter_column(
+        'biocommons_user',
+        'account_type',
+        existing_type=account_type_enum,
+        nullable=False,
+        server_default=None,
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('biocommons_user', 'account_type')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "loguru>=0.7.3",
     "cachetools~=7.1",
     "typer>=0.26.8",
-    "starlette-admin>=0.16.1",
+    "starlette-admin>=0.17.1",
     # Security floor for CVE-2026-27199 (safe_join Windows device names)
     "werkzeug>=3.1.8",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dev = [
     "httpx2>=2.9.1",
     "pytest>=9.0.3",
     "pytest-mock>=3.14.0",
+	"pytest-sugar>=1.1.1",
     "pytest-asyncio~=1.2",
     "pytest-cov>=4.1.0",
     "ruff>=0.4.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "boto3-stubs>=1.43.45",
+    "httpx2>=2.9.1",
     "pytest>=9.0.3",
     "pytest-mock>=3.14.0",
     "pytest-asyncio~=1.2",

--- a/routers/user.py
+++ b/routers/user.py
@@ -17,6 +17,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlmodel import Session, select
 from starlette.responses import RedirectResponse
 
+from auth.account_permissions import AccountActions, require_account_permission
 from auth.management import get_management_token
 from auth.ses import EmailService, get_email_service
 from auth.user_permissions import get_db_user, get_session_user, user_is_general_admin
@@ -574,6 +575,7 @@ async def get_all_pending(
         200: {"model": Auth0UserData},
         400: {"model": FieldErrorResponse},
     },
+    dependencies=[require_account_permission(AccountActions.CHANGE_USERNAME)],
 )
 async def update_username(
     username: Annotated[BiocommonsUsername, Body(embed=True)],
@@ -654,7 +656,8 @@ class NameUpdateRequest(BaseModel):
 
 
 @router.post("/profile/name/update",
-             response_model=Auth0UserData)
+             response_model=Auth0UserData,
+             dependencies=[require_account_permission(AccountActions.CHANGE_NAME)])
 async def update_name(
     payload: Annotated[NameUpdateRequest, Body()],
     user: Annotated[SessionUser, Depends(get_session_user)],
@@ -695,6 +698,7 @@ async def update_name(
         200: {"model": dict},
         400: {"model": FieldErrorResponse},
     },
+    dependencies=[require_account_permission(AccountActions.CHANGE_EMAIL)]
 )
 async def update_email(
     payload: Annotated[EmailChangeRequest, Body()],
@@ -764,7 +768,8 @@ async def update_email(
 
 
 @router.post("/profile/email/continue",
-             response_model=Auth0UserData)
+             response_model=Auth0UserData,
+             dependencies=[require_account_permission(AccountActions.CHANGE_EMAIL)])
 async def continue_email_update(
     payload: Annotated[EmailChangeContinueRequest, Body()],
     user: Annotated[SessionUser, Depends(get_session_user)],
@@ -910,6 +915,7 @@ async def _revoke_sbp_if_non_institutional(
         200: {"model": dict},
         400: {"model": FieldErrorResponse},
     },
+    dependencies=[require_account_permission(AccountActions.CHANGE_PASSWORD)]
 )
 async def change_password(
     payload: PasswordChangeRequest,

--- a/routers/user.py
+++ b/routers/user.py
@@ -49,7 +49,7 @@ from dependencies.utils import request_time
 from register.tokens import validate_recaptcha
 from schemas.biocommons import (
     Auth0UserData,
-    BiocommonsAppMetadata,
+    BiocommonsAppMetadataUpdate,
     BiocommonsEmail,
     BiocommonsFirstName,
     BiocommonsLastName,
@@ -1058,7 +1058,7 @@ def finish_migrate_password(state: str,
         raise HTTPException(status_code=400, detail=f"Invalid session token: {e}")
     # NOTE: due to the way the update user endpoint works (app_metadata is merged, not replaced),
     #  this should not overwrite existing app_metadata
-    updated_metadata = BiocommonsAppMetadata(user_needs_migration=False)
+    updated_metadata = BiocommonsAppMetadataUpdate(user_needs_migration=False)
     logger.info(f"Updating app_metadata for user: {user_id}")
     auth0_client.update_user(user_id=user_id, update_data=UpdateUserData(app_metadata=updated_metadata))
 

--- a/scheduled_tasks/tasks.py
+++ b/scheduled_tasks/tasks.py
@@ -397,7 +397,10 @@ def parse_auth0_export(path: Path) -> list[ExportedUser]:
     return parsed
 
 
-async def export_auth0_users(auth0_client: Auth0Client) -> list[ExportedUser]:
+async def export_auth0_users(
+    auth0_client: Auth0Client,
+    connection_id: str | None = None,
+) -> list[ExportedUser]:
     """
     Export all users to CSV and return a list
     """
@@ -415,7 +418,11 @@ async def export_auth0_users(auth0_client: Auth0Client) -> list[ExportedUser]:
 
         logger.info(f"Exporting Auth0 users to {temp_path}")
         try:
-            auth0_client.export_and_download_users(download_path=temp_path, fields=fields)
+            auth0_client.export_and_download_users(
+                download_path=temp_path,
+                fields=fields,
+                connection_id=connection_id,
+            )
         except HTTPStatusError as exc:
             logger.error(f"Failed to export Auth0 users: {exc}")
             logger.error(f"Response: {exc.response.content}")

--- a/scheduled_tasks/tasks.py
+++ b/scheduled_tasks/tasks.py
@@ -54,7 +54,7 @@ from schemas.auth0 import (
     PLATFORM_ROLE_PATTERN,
     get_platform_id_from_role_name,
 )
-from schemas.biocommons import Auth0UserData
+from schemas.biocommons import Auth0UserData, BiocommonsUserAccountType
 
 
 def chunked[T](items: list[T], size: int) -> list[list[T]]:
@@ -123,6 +123,23 @@ def _find_conflicting_user_by_email(
         )
 
 
+def _create_biocommons_user_from_sync_data(
+    user_data: Auth0UserData | ExportedUser,
+) -> BiocommonsUser:
+    account_type = (
+        user_data.app_metadata.account_type
+        if isinstance(user_data, Auth0UserData)
+        else BiocommonsUserAccountType.AUTH0
+    )
+    return BiocommonsUser(
+        id=user_data.user_id,
+        email=user_data.email,
+        username=user_data.username,
+        email_verified=user_data.email_verified,
+        account_type=account_type,
+    )
+
+
 def _ensure_user_from_auth0(
         session: Session,
         user_data: Auth0UserData | ExportedUser
@@ -181,7 +198,7 @@ def _ensure_user_from_auth0(
             )
         else:
             created = True
-            user = BiocommonsUser.from_auth0_data(user_data)
+            user = _create_biocommons_user_from_sync_data(user_data)
     session.add(user)
 
     # Save history entry if updating from Auth0 sync
@@ -519,7 +536,7 @@ def _create_user_in_db(user_data: ExportedUser, session: Session):
     email_conflict = BiocommonsUser.get_by_email(user_data.email, session, include_deleted=True)
     if email_conflict is not None:
         raise UserSyncConflictError(f"Email {user_data.email} is already in use")
-    db_user = BiocommonsUser.from_auth0_data(user_data)
+    db_user = _create_biocommons_user_from_sync_data(user_data)
     session.add(db_user)
     return db_user
 

--- a/scheduled_tasks/tasks.py
+++ b/scheduled_tasks/tasks.py
@@ -453,7 +453,10 @@ async def sync_auth0_users():
     settings = get_settings()
     token = get_management_token(settings=settings)
     with Auth0Client(domain=settings.auth0_domain, management_token=token) as auth0_client:
-        users = await export_auth0_users(auth0_client)
+        db_connection = auth0_client.get_connection_by_name(settings.auth0_db_connection)
+        if db_connection is None:
+            raise ValueError(f"Could not find Auth0 connection: {settings.auth0_db_connection}")
+        users = await export_auth0_users(auth0_client, connection_id=db_connection.id)
         db_session = next(get_db_session())
         auth0_user_ids: set[str] = set()
         try:

--- a/scheduled_tasks/tasks.py
+++ b/scheduled_tasks/tasks.py
@@ -71,6 +71,7 @@ class ExportedUser(BaseModel):
     username: str | None
     blocked: bool
     updated_at: datetime
+    account_type: BiocommonsUserAccountType = BiocommonsUserAccountType.AUTH0
 
     @field_validator("email_verified", "blocked", mode="before")
     @classmethod
@@ -129,7 +130,7 @@ def _create_biocommons_user_from_sync_data(
     account_type = (
         user_data.app_metadata.account_type
         if isinstance(user_data, Auth0UserData)
-        else BiocommonsUserAccountType.AUTH0
+        else user_data.account_type
     )
     return BiocommonsUser(
         id=user_data.user_id,
@@ -391,6 +392,7 @@ def parse_auth0_export(path: Path) -> list[ExportedUser]:
                 username=row["username"].lstrip("'") or None,
                 blocked=row["blocked"],
                 updated_at=row["updated_at"],
+                account_type=row.get("account_type", "").lstrip("'") or BiocommonsUserAccountType.AUTH0,
             ))
     return parsed
 
@@ -405,7 +407,8 @@ async def export_auth0_users(auth0_client: Auth0Client) -> list[ExportedUser]:
         {"name": "email_verified"},
         {"name": "username"},
         {"name": "blocked"},
-        {"name": "updated_at"}
+        {"name": "updated_at"},
+        {"name": "app_metadata.account_type", "export_as": "account_type"},
     ]
     with tempfile.TemporaryDirectory() as temp_dir:
         temp_path = Path(temp_dir) / "auth0_users.csv"

--- a/schemas/biocommons.py
+++ b/schemas/biocommons.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import re
 from datetime import datetime
+from enum import StrEnum
 from typing import TYPE_CHECKING, Annotated, List, Literal, Optional, Self
 
 from email_validator import EmailNotValidError, validate_email
@@ -158,6 +159,11 @@ class BPAMetadata(BaseModel):
 
 class SBPMetadata(BaseModel):
     registration_reason: str
+
+
+class BiocommonsUserAccountType(StrEnum):
+    AUTH0 = "auth0"
+    AAF = "aaf"
 
 
 class BiocommonsUserMetadata(BaseModel):

--- a/schemas/biocommons.py
+++ b/schemas/biocommons.py
@@ -19,6 +19,7 @@ from pydantic import (
     EmailStr,
     Field,
     HttpUrl,
+    field_validator,
 )
 from pydantic_core import PydanticCustomError
 
@@ -190,6 +191,32 @@ class BiocommonsAppMetadata(BaseModel):
     registration_from: Optional[AppId] = None
     old_emails: Optional[list[OldEmailRecord]] = None
     user_needs_migration: Optional[bool] = None
+    account_type: BiocommonsUserAccountType
+
+    model_config = {
+        "extra": "ignore"
+    }
+
+
+class Auth0ReadAppMetadata(BiocommonsAppMetadata):
+    """
+    Schema for data we get from Auth0 - older data might not
+    contain account_type so make this less strict than the core schema
+    """
+    account_type: BiocommonsUserAccountType = BiocommonsUserAccountType.AUTH0
+
+
+class BiocommonsAppMetadataUpdate(BaseModel):
+    """
+    Partial app_metadata patch sent to Auth0.
+
+    Auth0 merges app_metadata fields when updating, so updates should not
+    need to repeat fields that are not changing.
+    """
+    registration_from: Optional[AppId] = None
+    old_emails: Optional[list[OldEmailRecord]] = None
+    user_needs_migration: Optional[bool] = None
+    account_type: Optional[BiocommonsUserAccountType] = None
 
     model_config = {
         "extra": "ignore"
@@ -235,6 +262,9 @@ class BiocommonsRegisterData(BaseModel):
             connection="Username-Password-Authentication",
             app_metadata=BiocommonsAppMetadata(
                 registration_from="biocommons",
+                # NOTE: users we register should always have account_type: Auth0,
+                # since we don't register AAF users this way
+                account_type=BiocommonsUserAccountType.AUTH0,
             ),
         )
 
@@ -274,13 +304,17 @@ class Auth0UserData(BaseModel):
     updated_at: datetime
     user_id: str
     blocked: Optional[bool] = None
-    # Auth0 will not include user/app metadata in the response when
-    #   empty, so make it optional
+    # Auth0 will not include user_metadata in the response when empty.
     user_metadata: Optional[BiocommonsUserMetadata] = None
-    app_metadata: Optional[BiocommonsAppMetadata] = None
+    app_metadata: Auth0ReadAppMetadata = Field(default_factory=Auth0ReadAppMetadata)
     last_ip: Optional[str] = None
     last_login: Optional[datetime] = None
     logins_count: Optional[int] = None
+
+    @field_validator("app_metadata", mode="before")
+    @classmethod
+    def _default_app_metadata(cls, value):
+        return {} if value is None else value
 
 
 class Auth0UserDataWithMemberships(Auth0UserData):

--- a/tests/auth/test_account_permissions.py
+++ b/tests/auth/test_account_permissions.py
@@ -1,0 +1,85 @@
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from auth.account_permissions import (
+    AccountActions,
+    account_action_allowed,
+    require_account_permission,
+)
+from auth.user_permissions import get_db_user
+from tests.db.datagen import BiocommonsUserFactory
+
+
+@pytest.mark.parametrize(
+    ["action", "expected"],
+    [(action, True) for action in AccountActions]
+)
+def test_account_action_allowed_auth0(action: AccountActions, expected: bool, persistent_factories):
+    """
+    Test which actions are allowed for auth0 accounts (currently all actions are allowed)
+    """
+    user = BiocommonsUserFactory.create_sync(account_type="auth0")
+    allowed = account_action_allowed(action=action, user=user)
+    assert allowed == expected
+
+
+@pytest.mark.parametrize(
+    ["action", "expected"],
+    [
+        (AccountActions.CHANGE_EMAIL, False),
+        (AccountActions.CHANGE_USERNAME, True),
+        (AccountActions.CHANGE_PASSWORD, False),
+        (AccountActions.CHANGE_NAME, True)
+    ]
+)
+def test_account_action_allowed_aaf(action: AccountActions, expected: bool, persistent_factories):
+    """
+    Test which actions are allowed for AAF accounts
+    """
+    user = BiocommonsUserFactory.create_sync(account_type="aaf")
+    allowed = account_action_allowed(action=action, user=user)
+    assert allowed == expected
+
+
+@pytest.mark.parametrize(
+    ["allowed", "expected_status", "expected_json"],
+    [
+        (True, 200, {"result": "ok"}),
+        (
+            False,
+            403,
+            {"detail": "You do not have permission to perform this action."},
+        ),
+    ],
+)
+def test_require_account_permission_dependency(
+    allowed: bool,
+    expected_status: int,
+    expected_json: dict,
+    mocker,
+):
+    user = BiocommonsUserFactory.build(account_type="aaf")
+    account_action_allowed_mock = mocker.patch(
+        "auth.account_permissions.account_action_allowed",
+        return_value=allowed,
+    )
+    app = FastAPI()
+    app.dependency_overrides[get_db_user] = lambda: user
+
+    @app.get(
+        "/dummy",
+        dependencies=[require_account_permission(AccountActions.CHANGE_EMAIL)],
+    )
+    def dummy_endpoint():
+        return {"result": "ok"}
+
+    client = TestClient(app)
+    response = client.get("/dummy")
+
+    assert response.status_code == expected_status
+    assert response.json() == expected_json
+    account_action_allowed_mock.assert_called_once_with(
+        AccountActions.CHANGE_EMAIL,
+        user,
+    )

--- a/tests/auth/test_account_permissions.py
+++ b/tests/auth/test_account_permissions.py
@@ -28,7 +28,7 @@ def test_account_action_allowed_auth0(action: AccountActions, expected: bool, pe
     ["action", "expected"],
     [
         (AccountActions.CHANGE_EMAIL, False),
-        (AccountActions.CHANGE_USERNAME, True),
+        (AccountActions.CHANGE_USERNAME, False),
         (AccountActions.CHANGE_PASSWORD, False),
         (AccountActions.CHANGE_NAME, True)
     ]

--- a/tests/datagen.py
+++ b/tests/datagen.py
@@ -18,6 +18,7 @@ from auth0.user_info import UserInfo
 from scheduled_tasks.tasks import ExportedUser
 from schemas.biocommons import (
     ALLOWED_SPECIAL_CHARS,
+    Auth0ReadAppMetadata,
     Auth0UserData,
     BiocommonsAppMetadata,
     BiocommonsPassword,
@@ -124,6 +125,9 @@ class Auth0UserDataFactory(ModelFactory[Auth0UserData]):
 
 
 class AppMetadataFactory(ModelFactory[BiocommonsAppMetadata]): ...
+
+
+class Auth0ReadAppMetadataFactory(ModelFactory[Auth0ReadAppMetadata]): ...
 
 
 class BiocommonsRegistrationDataFactory(ModelFactory[BiocommonsRegistrationRequest]):

--- a/tests/datagen.py
+++ b/tests/datagen.py
@@ -9,6 +9,8 @@ from polyfactory.factories.pydantic_factory import ModelFactory
 from pydantic import TypeAdapter, ValidationError
 
 from auth0.client import (
+    Auth0Connection,
+    ConnectionsWithCheckpoint,
     EmailVerificationResponse,
     RoleUserData,
     RoleUsersWithTotals,
@@ -122,6 +124,16 @@ class Auth0UserDataFactory(ModelFactory[Auth0UserData]):
     username = BiocommonsProviders.biocommons_username
     # blocked = False by default
     blocked = False
+
+
+class Auth0ConnectionFactory(ModelFactory[Auth0Connection]):
+
+    @classmethod
+    def options(cls):
+        return {}
+
+
+class ConnectionsWithCheckpointFactory(ModelFactory[ConnectionsWithCheckpoint]): ...
 
 
 class AppMetadataFactory(ModelFactory[BiocommonsAppMetadata]): ...

--- a/tests/db/datagen.py
+++ b/tests/db/datagen.py
@@ -11,6 +11,7 @@ from db.models import (
     PlatformMembership,
 )
 from db.types import ApprovalStatusEnum, PlatformEnum
+from schemas.biocommons import BiocommonsUserAccountType
 from tests.datagen import BiocommonsProviders, random_auth0_id
 
 fake = Faker()
@@ -34,6 +35,10 @@ class BiocommonsUserFactory(SQLAlchemyFactory[BiocommonsUser]):
     @classmethod
     def is_deleted(cls) -> bool:
         return False
+
+    @classmethod
+    def account_type(cls) -> BiocommonsUserAccountType:
+        return BiocommonsUserAccountType.AUTH0
 
 
 class Auth0RoleFactory(SQLAlchemyFactory[Auth0Role]):

--- a/tests/db/test_models.py
+++ b/tests/db/test_models.py
@@ -27,6 +27,7 @@ from schemas.biocommons import BiocommonsUserAccountType
 from tests.biocommons.datagen import RoleDataFactory
 from tests.datagen import (
     AccessTokenPayloadFactory,
+    AppMetadataFactory,
     Auth0UserDataFactory,
     RoleUserDataFactory,
     random_auth0_id,
@@ -59,7 +60,7 @@ def test_create_biocommons_user(test_db_session):
     user_data = Person(locale=Locale("en"))
     auth0_id = random_auth0_id()
     email = user_data.email()
-    user = BiocommonsUser(id=auth0_id, email=email, username="user_name")
+    user = BiocommonsUser(id=auth0_id, email=email, username="user_name", account_type="auth0")
     test_db_session.add(user)
     test_db_session.commit()
     test_db_session.refresh(user)
@@ -83,7 +84,9 @@ def test_create_biocommons_user_from_auth0(test_db_session, mock_auth0_client):
     """
     Test creating the BiocommonsUser model from Auth0 user data from the API
     """
-    user_data = Auth0UserDataFactory.build()
+    user_data = Auth0UserDataFactory.build(
+        app_metadata=AppMetadataFactory.build(account_type=BiocommonsUserAccountType.AUTH0)
+    )
     mock_auth0_client.get_user.return_value = user_data
     user = BiocommonsUser.create_from_auth0(auth0_id=user_data.user_id, auth0_client=mock_auth0_client)
     test_db_session.add(user)
@@ -1513,6 +1516,7 @@ def test_soft_delete_recreate_revives_deleted(test_db_session, persistent_factor
     user = BiocommonsUserFactory.create_sync(
         email="user@example.com",
         username="soft_delete_user",
+        account_type=BiocommonsUserAccountType.AUTH0
     )
     test_db_session.commit()
 
@@ -1524,6 +1528,7 @@ def test_soft_delete_recreate_revives_deleted(test_db_session, persistent_factor
         email="new@example.com",
         username="soft_delete_user",
         email_verified=True,
+        account_type=BiocommonsUserAccountType.AUTH0
     )
     test_db_session.add(replacement)
     test_db_session.commit()

--- a/tests/db/test_models.py
+++ b/tests/db/test_models.py
@@ -27,7 +27,7 @@ from schemas.biocommons import BiocommonsUserAccountType
 from tests.biocommons.datagen import RoleDataFactory
 from tests.datagen import (
     AccessTokenPayloadFactory,
-    AppMetadataFactory,
+    Auth0ReadAppMetadataFactory,
     Auth0UserDataFactory,
     RoleUserDataFactory,
     random_auth0_id,
@@ -85,7 +85,7 @@ def test_create_biocommons_user_from_auth0(test_db_session, mock_auth0_client):
     Test creating the BiocommonsUser model from Auth0 user data from the API
     """
     user_data = Auth0UserDataFactory.build(
-        app_metadata=AppMetadataFactory.build(account_type=BiocommonsUserAccountType.AUTH0)
+        app_metadata=Auth0ReadAppMetadataFactory.build(account_type=BiocommonsUserAccountType.AUTH0)
     )
     mock_auth0_client.get_user.return_value = user_data
     user = BiocommonsUser.create_from_auth0(auth0_id=user_data.user_id, auth0_client=mock_auth0_client)

--- a/tests/db/test_models.py
+++ b/tests/db/test_models.py
@@ -23,6 +23,7 @@ from db.models import (
     PlatformMembership,
     PlatformMembershipHistory,
 )
+from schemas.biocommons import BiocommonsUserAccountType
 from tests.biocommons.datagen import RoleDataFactory
 from tests.datagen import (
     AccessTokenPayloadFactory,
@@ -66,6 +67,16 @@ def test_create_biocommons_user(test_db_session):
     assert user.email == email
     assert user.username == "user_name"
     assert not user.email_verified
+
+
+def test_biocommons_user_account_type_db_enum_uses_enum_values():
+    """
+    Test that account_type uses the string values from the account type
+    enum, not the enum names
+    """
+    db_enum = BiocommonsUser.__table__.c.account_type.type
+
+    assert db_enum.enums == [account_type.value for account_type in BiocommonsUserAccountType]
 
 
 def test_create_biocommons_user_from_auth0(test_db_session, mock_auth0_client):

--- a/tests/db/test_utils.py
+++ b/tests/db/test_utils.py
@@ -71,17 +71,11 @@ def test_refresh_unverified_users_task_gets_auth0_client_when_none(test_db_sessi
     auth0_client.close.assert_called_once()
 
 
-def test_refresh_unverified_users_updates_status(test_db_session: Session):
+def test_refresh_unverified_users_updates_status(test_db_session: Session, persistent_factories):
     """Verifies that a user's status is updated when Auth0 reports they are now verified."""
     # Create an unverified user
-    user = BiocommonsUser(
-        id="auth0|123",
-        email="test@example.com",
-        username="testuser",
-        email_verified=False,
-    )
-    test_db_session.add(user)
-    test_db_session.commit()
+    user = BiocommonsUserFactory.create_sync(email_verified=False)
+    user_id = user.id
 
     # Mock Auth0 to return verified=True
     auth0_client = MagicMock()
@@ -93,13 +87,13 @@ def test_refresh_unverified_users_updates_status(test_db_session: Session):
 
     # Re-fetch user to check update
     db_session_new = Session(test_db_session.bind)  # Use fresh session to avoid cache
-    updated_user = db_session_new.exec(select(BiocommonsUser).where(BiocommonsUser.id == "auth0|123")).one()
+    updated_user = db_session_new.exec(select(BiocommonsUser).where(BiocommonsUser.id == user_id)).one()
     assert updated_user.email_verified is True
 
 
-def test_refresh_unverified_users_skips_verified_users(test_db_session):
+def test_refresh_unverified_users_skips_verified_users(test_db_session, persistent_factories):
     """Verifies that the query only targets users where email_verified is False."""
-    user = BiocommonsUser(
+    user = BiocommonsUserFactory.create_sync(
         id="auth0|456",
         email="verified@example.com",
         username="verified",

--- a/tests/migrations/test_migrations.py
+++ b/tests/migrations/test_migrations.py
@@ -6,6 +6,7 @@ from sqlalchemy import text
 from sqlmodel import Session, create_engine
 
 from db.models import BiocommonsGroup
+from schemas.biocommons import BiocommonsUserAccountType
 
 
 def test_sbp_group_migration_creates_expected_group(tmp_path, mocker):
@@ -108,5 +109,64 @@ def test_sbp_cleanup_migration_removes_legacy_group_and_recreates_current_group(
             assert group.name == "Structural Biology Platform Bundle"
             assert group.short_name == "SBP"
             assert group.is_deleted is False
+    finally:
+        engine.dispose()
+
+
+def test_user_account_type_migration_backfills_existing_users(tmp_path, mocker):
+    db_path = tmp_path / "user_account_type_migration.sqlite"
+    db_url = f"sqlite:///{db_path}"
+
+    mocker.patch("db.setup.get_db_config", return_value=(db_url, {"check_same_thread": False}))
+
+    repo_root = Path(__file__).resolve().parents[2]
+    alembic_config = Config(str(repo_root / "alembic.ini"))
+
+    command.upgrade(alembic_config, "39caad32922e")
+
+    engine = create_engine(
+        db_url,
+        connect_args={"check_same_thread": False},
+    )
+    try:
+        with Session(engine) as session:
+            session.exec(
+                text(
+                    """
+                    INSERT INTO biocommons_user (
+                        id,
+                        email,
+                        email_verified,
+                        username,
+                        created_at,
+                        is_deleted
+                    )
+                    VALUES (
+                        'auth0|existing-user',
+                        'existing@example.com',
+                        FALSE,
+                        'existing_user',
+                        '2026-08-06 00:00:00',
+                        FALSE
+                    )
+                    """
+                )
+            )
+            session.commit()
+
+        command.upgrade(alembic_config, "0c91366532ae")
+
+        with Session(engine) as session:
+            account_type = session.exec(
+                text(
+                    """
+                    SELECT account_type
+                    FROM biocommons_user
+                    WHERE id = 'auth0|existing-user'
+                    """
+                )
+            ).one()[0]
+
+            assert account_type == BiocommonsUserAccountType.AUTH0.value
     finally:
         engine.dispose()

--- a/tests/scheduled_tasks/test_tasks.py
+++ b/tests/scheduled_tasks/test_tasks.py
@@ -1238,7 +1238,8 @@ async def test_export_auth0_users_writes_temp_csv_file(mocker):
     csv_existed_at_parse_time = False
     csv_path: Path | None = None
 
-    def _fake_export_and_download_users(*, download_path, fields):
+    def _fake_export_and_download_users(*, download_path, fields, connection_id):
+        assert connection_id is None
         # Simulate Auth0Client writing the file to the provided temp path
         download_path.write_text(
             "user_id,email,email_verified,username,blocked,updated_at\n"
@@ -1276,3 +1277,30 @@ async def test_export_auth0_users_writes_temp_csv_file(mocker):
     assert not csv_path.exists()
     assert len(users) == 1
     assert users[0].user_id == "auth0|u1"
+
+
+@pytest.mark.asyncio
+async def test_export_auth0_users_passes_connection_id(mocker):
+    def _fake_export_and_download_users(*, download_path, fields, connection_id):
+        assert fields == [
+            {"name": "user_id"},
+            {"name": "email"},
+            {"name": "email_verified"},
+            {"name": "username"},
+            {"name": "blocked"},
+            {"name": "updated_at"},
+            {"name": "app_metadata.account_type", "export_as": "account_type"},
+        ]
+        assert connection_id == "con_aaf"
+        download_path.write_text(
+            "user_id,email,email_verified,username,blocked,updated_at,account_type\n",
+            encoding="utf-8",
+        )
+
+    auth0_client = MagicMock()
+    auth0_client.export_and_download_users.side_effect = _fake_export_and_download_users
+
+    users = await export_auth0_users(auth0_client, connection_id="con_aaf")
+
+    assert users == []
+    auth0_client.export_and_download_users.assert_called_once()

--- a/tests/scheduled_tasks/test_tasks.py
+++ b/tests/scheduled_tasks/test_tasks.py
@@ -44,6 +44,7 @@ from scheduled_tasks.tasks import (
     update_auth0_user,
     update_auth0_users_batch,
 )
+from schemas.biocommons import BiocommonsUserAccountType
 from tests.datagen import (
     Auth0UserDataFactory,
     ExportedUserFactory,
@@ -1184,9 +1185,9 @@ async def test_process_email_queue_skips_when_retry_window_exceeded(test_db_sess
 def test_parse_auth0_export_parses_csv_file(tmp_path):
     csv_path = tmp_path / "auth0_users.csv"
     csv_path.write_text(
-        "user_id,email,email_verified,username,blocked,updated_at\n"
-        "'auth0|u1,'u1@example.com,True,'u1,False,2024-01-01T12:00:00+00:00\n"
-        "'auth0|u2,'u2@example.com,,,,2024-01-02T12:00:00+00:00\n",
+        "user_id,email,email_verified,username,blocked,updated_at,account_type\n"
+        "'auth0|u1,'u1@example.com,True,'u1,False,2024-01-01T12:00:00+00:00,'aaf\n"
+        "'auth0|u2,'u2@example.com,,,,2024-01-02T12:00:00+00:00,\n",
         encoding="utf-8",
     )
 
@@ -1201,6 +1202,7 @@ def test_parse_auth0_export_parses_csv_file(tmp_path):
     assert users[0].username == "u1"
     assert users[0].blocked is False
     assert users[0].updated_at.isoformat() == "2024-01-01T12:00:00+00:00"
+    assert users[0].account_type == BiocommonsUserAccountType.AAF
 
 
     assert users[1].user_id == "auth0|u2"
@@ -1211,6 +1213,20 @@ def test_parse_auth0_export_parses_csv_file(tmp_path):
     # Check empty username parses as None
     assert users[1].username is None
     assert users[1].updated_at.isoformat() == "2024-01-02T12:00:00+00:00"
+    assert users[1].account_type == BiocommonsUserAccountType.AUTH0
+
+
+def test_parse_auth0_export_defaults_account_type_when_field_missing(tmp_path):
+    csv_path = tmp_path / "auth0_users.csv"
+    csv_path.write_text(
+        "user_id,email,email_verified,username,blocked,updated_at\n"
+        "'auth0|u1,'u1@example.com,True,'u1,False,2024-01-01T12:00:00+00:00\n",
+        encoding="utf-8",
+    )
+
+    users = parse_auth0_export(csv_path)
+
+    assert users[0].account_type == BiocommonsUserAccountType.AUTH0
 
 
 @pytest.mark.asyncio

--- a/tests/test_auth0_client.py
+++ b/tests/test_auth0_client.py
@@ -13,8 +13,10 @@ from auth0.client import (
     UpdateUserData,
 )
 from tests.datagen import (
+    Auth0ConnectionFactory,
     Auth0UserDataFactory,
     BiocommonsRegisterDataFactory,
+    ConnectionsWithCheckpointFactory,
     EmailVerificationResponseFactory,
     random_auth0_id,
     random_auth0_role_id,
@@ -63,6 +65,32 @@ def test_get_user_by_id(test_auth0_client):
 
     assert route.called
     assert result.model_dump(mode="json") == user.model_dump(mode="json")
+
+
+@respx.mock
+def test_get_connections(test_auth0_client):
+    connections = Auth0ConnectionFactory.batch(3)
+    resp = ConnectionsWithCheckpointFactory.build(connections=connections, next=None)
+    route = respx.get("https://auth0.example.com/api/v2/connections").respond(200, json=resp.model_dump(mode="json"))
+
+    result = test_auth0_client.get_connections()
+
+    assert route.called
+    assert result == connections
+
+
+@respx.mock
+def test_get_connection_by_name(test_auth0_client):
+    db_connection = Auth0ConnectionFactory.build(name="db_connection")
+    other = Auth0ConnectionFactory.build(name="other")
+    resp = ConnectionsWithCheckpointFactory.build(connections=[db_connection, other])
+    route = respx.get("https://auth0.example.com/api/v2/connections").respond(200, json=resp.model_dump(mode="json"))
+
+    result = test_auth0_client.get_connection_by_name(db_connection.name)
+
+    assert route.called
+    assert result == db_connection
+
 
 
 @respx.mock

--- a/tests/test_auth0_client.py
+++ b/tests/test_auth0_client.py
@@ -324,6 +324,41 @@ def test_export_and_download_users_starts_job_waits_and_downloads(test_auth0_cli
         {"name": "email"},
         {"name": "username"},
     ]
+    assert "connection_id" not in start_payload
+
+
+@respx.mock
+def test_export_and_download_users_passes_connection_id(test_auth0_client, tmp_path, monkeypatch):
+    monkeypatch.setattr(time, "sleep", lambda *_args, **_kwargs: None)
+
+    export_job_id = "job_123"
+    download_url = "https://downloads.example.com/users.csv"
+    csv_text = "user_id,email,username\nauth0|1,test@example.com,test\n"
+
+    start_route = respx.post("https://auth0.example.com/api/v2/jobs/users-exports").respond(
+        200,
+        json={"id": export_job_id},
+    )
+    respx.get(f"https://auth0.example.com/api/v2/jobs/{export_job_id}").respond(
+        200,
+        json={
+            "id": export_job_id,
+            "status": "completed",
+            "type": "users_export",
+            "created_at": "2020-01-01T00:00:00Z",
+            "location": download_url,
+        },
+    )
+    respx.get(download_url).respond(200, text=csv_text)
+
+    out_path = tmp_path / "auth0_users.csv"
+    test_auth0_client.export_and_download_users(
+        out_path,
+        connection_id="con_aaf",
+    )
+
+    start_payload = json.loads(start_route.calls[0].request.content)
+    assert start_payload["connection_id"] == "con_aaf"
 
 
 @respx.mock

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -86,6 +86,6 @@ def test_aai_portal_url_override_strips_trailing_slash():
     assert settings.aai_portal_url == "https://example.test"
 
 
-def test_unknown_environment_requires_explicit_portal_url():
-    with pytest.raises(ValidationError, match="Input should be 'dev', 'staging' or 'production'"):
+def test_unknown_environment_raises_error():
+    with pytest.raises(ValidationError, match="Input should be 'dev', 'staging', 'production' or 'dev-aaf'"):
         Settings(_env_file=None, environment="qa", **_base_settings_kwargs())

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -913,6 +913,44 @@ def test_get_admin_groups(test_client, test_db_session, mocker, persistent_facto
     assert invalid_group.group_id not in returned_ids
 
 
+@pytest.mark.parametrize(
+    ["endpoint", "payload"],
+    [
+        ("/me/profile/email/update", {"email": "new@example.com"}),
+        ("/me/profile/email/continue", {"otp": "123456"}),
+        (
+            "/me/profile/password/update",
+            {
+                "current_password": "CurrentPass123!",
+                "new_password": "NewPass123!",
+            },
+        ),
+    ],
+)
+def test_profile_update_endpoints_disallowed_for_aaf_accounts(
+    endpoint,
+    payload,
+    test_client,
+    test_db_session,
+    mocker,
+    persistent_factories,
+):
+    user = BiocommonsUserFactory.create_sync(account_type="aaf")
+    test_db_session.commit()
+    _act_as_user(mocker, user)
+
+    response = test_client.post(
+        endpoint,
+        headers={"Authorization": "Bearer valid_token"},
+        json=payload,
+    )
+
+    assert response.status_code == HTTPStatus.FORBIDDEN
+    assert response.json() == {
+        "detail": "You do not have permission to perform this action."
+    }
+
+
 def test_update_username(test_client, test_db_session, mocker, persistent_factories):
     user = BiocommonsUserFactory.create_sync(username="old_username")
     mock_data = Auth0UserDataFactory.build(sub=user.id, username="new_username")

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -24,7 +24,11 @@ from db.types import (
     PlatformEnum,
 )
 from routers.user import get_user_data, update_user_metadata
-from schemas.biocommons import Auth0Identity, BiocommonsAppMetadata
+from schemas.biocommons import (
+    Auth0Identity,
+    Auth0ReadAppMetadata,
+    BiocommonsAppMetadata,
+)
 from tests.datagen import (
     AccessTokenPayloadFactory,
     Auth0UserDataFactory,
@@ -1072,12 +1076,12 @@ def test_email_continue_updates_user(test_client, test_db_session, mocker, persi
         sub=user.id,
         email="new@example.com",
         email_verified=True,
-        app_metadata=BiocommonsAppMetadata(registration_from="biocommons"),
+        app_metadata=Auth0ReadAppMetadata(registration_from="biocommons", account_type="auth0"),
     )
     current_auth0_user = Auth0UserDataFactory.build(
         sub=user.id,
         email=user.email,
-        app_metadata=BiocommonsAppMetadata(registration_from="biocommons"),
+        app_metadata=Auth0ReadAppMetadata(registration_from="biocommons", account_type="auth0"),
     )
     mocker.patch("routers.user.Auth0Client.update_user", return_value=updated_user)
     mocker.patch("routers.user.Auth0Client.get_user", return_value=current_auth0_user)
@@ -1156,7 +1160,7 @@ def _setup_email_change_with_sbp(
         sub=user.id,
         email=new_email,
         email_verified=True,
-        app_metadata=BiocommonsAppMetadata(registration_from="biocommons"),
+        app_metadata=Auth0ReadAppMetadata(registration_from="biocommons"),
     )
     mock_auth0_client.update_user.return_value = updated_user
     mock_auth0_client.get_role_by_name.return_value = MagicMock(id="role_sbp")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,7 +9,10 @@ from db.models import EmailNotification
 from main import app
 from routers import utils
 from services.institutions import GALAXY_AU_VALIDATE_URL
-from tests.datagen import AppMetadataFactory, Auth0UserDataFactory
+from tests.datagen import (
+    Auth0ReadAppMetadataFactory,
+    Auth0UserDataFactory,
+)
 
 
 @pytest.fixture
@@ -28,7 +31,7 @@ def test_get_registration_info(override_auth0_client, test_client):
     Test we can look up a user by email, and return their
     app_metadata.registration_from value, if available.
     """
-    app_metadata = AppMetadataFactory.build(registration_from="galaxy")
+    app_metadata = Auth0ReadAppMetadataFactory.build(registration_from="galaxy")
     user = Auth0UserDataFactory.build(email="user@example.com",
                                       app_metadata=app_metadata)
     override_auth0_client.search_users_by_email.return_value = [user]
@@ -42,7 +45,7 @@ def test_get_registration_info_no_registration_from(override_auth0_client, test_
     """
     Test the default of 'biocommons' is returned if registration_from isn't set.
     """
-    app_metadata = AppMetadataFactory.build(registration_from=None)
+    app_metadata = Auth0ReadAppMetadataFactory.build(registration_from=None)
     user = Auth0UserDataFactory.build(email="user@example.com",
                                       app_metadata=app_metadata)
     override_auth0_client.search_users_by_email.return_value = [user]

--- a/uv.lock
+++ b/uv.lock
@@ -86,7 +86,7 @@ requires-dist = [
     { name = "respx", marker = "extra == 'dev'", specifier = ">=0.22.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4.4" },
     { name = "sqlmodel", specifier = ">=0.0.39" },
-    { name = "starlette-admin", specifier = ">=0.16.1" },
+    { name = "starlette-admin", specifier = ">=0.17.1" },
     { name = "typer", specifier = ">=0.26.8" },
     { name = "werkzeug", specifier = ">=3.1.8" },
 ]
@@ -1656,16 +1656,16 @@ wheels = [
 
 [[package]]
 name = "starlette-admin"
-version = "0.16.1"
+version = "0.17.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jinja2" },
     { name = "python-multipart" },
     { name = "starlette" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8d/36/a566ba401ba9cbf5da74a7697e0ae3d1294a8ab7211bb1d7d18f0ce42b3f/starlette_admin-0.16.1.tar.gz", hash = "sha256:f34bdba033f0a2a4b39188e8e70a684956ef6b774db01762f44d022cde418b3a", size = 2104666, upload-time = "2026-06-06T20:10:40.307Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/1d/49347d67cf11a453d6f8379e0b87e6c1ecc671dee347f61de8240c5d2b11/starlette_admin-0.17.1.tar.gz", hash = "sha256:7bdeaf1c30fd9036ef3779fb0255002d3d18aaf6f7e674200e21c604ee563fc7", size = 2106865, upload-time = "2026-07-20T06:13:58.132Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/7c/add7d4be6690fb61f4d30b672e544b1ac541c824f05a7de50ff5d8985db5/starlette_admin-0.16.1-py3-none-any.whl", hash = "sha256:a5e6cb0beb2e9bdc65b07dbb4bd01726aaad34764595e3bc3ff8578e698ff98a", size = 2176514, upload-time = "2026-06-06T20:10:42.308Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/d1/5fc2df30b98b59cc81b8184b66ca5d76fe194a7a9ff5197b70a23e49fc0b/starlette_admin-0.17.1-py3-none-any.whl", hash = "sha256:685615945d55de636879e3523ec70a6419176f7cd6f04a17470e35670f96b972", size = 2183488, upload-time = "2026-07-20T06:13:56.048Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ exclude-newer-span = "P7D"
 
 [[package]]
 name = "aai-backend"
-version = "1.3.0"
+version = "1.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
@@ -41,6 +41,7 @@ dev = [
     { name = "boto3-stubs" },
     { name = "faker" },
     { name = "freezegun" },
+    { name = "httpx2" },
     { name = "mimesis" },
     { name = "moto" },
     { name = "polyfactory" },
@@ -67,6 +68,7 @@ requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = ">=0.139.0" },
     { name = "freezegun", marker = "extra == 'dev'", specifier = ">=1.5.2" },
     { name = "httpx", specifier = ">=0.28.1" },
+    { name = "httpx2", marker = "extra == 'dev'", specifier = ">=2.9.1" },
     { name = "itsdangerous", specifier = ">=2.2.0" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "mimesis", marker = "extra == 'dev'", specifier = "~=18.0" },
@@ -731,6 +733,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/a8/20ed1ed79cbc2ecdf5301c0968ab7c85547212e2a7bd126ddd2d986e206e/httpcore2-2.9.1.tar.gz", hash = "sha256:4d8acbf8b306f48c9d6046591fd5ba4037d1b1b1000d140fc2c3eab1e9a0c0e2", size = 67089, upload-time = "2026-07-24T09:21:03.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/fb/46c52b781975c335a2bcf1072c7bbc007cbdc8d674217f5ee1daba2c848b/httpcore2-2.9.1-py3-none-any.whl", hash = "sha256:6182472379e855fe4221246a2bb7ecede403bc61c6798062ae1787d051ccde26", size = 82809, upload-time = "2026-07-24T09:21:01.178Z" },
+]
+
+[[package]]
 name = "httptools"
 version = "0.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -768,6 +783,21 @@ wheels = [
 ]
 
 [[package]]
+name = "httpx2"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpcore2" },
+    { name = "idna" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/14/38128fbafd7e0ed41d874df6c9a653d47c2d111cfe59e2b4ac95161b4abd/httpx2-2.9.1.tar.gz", hash = "sha256:1932a768737e3666291582833da748cc4e563c337cf96706fccc04fa6e58764a", size = 95458, upload-time = "2026-07-24T09:21:04.972Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/b8/cfd91c4ab9134d386d48f0b6ac662ff3d4be6efdee59ee1c67ebc3c0487c/httpx2-2.9.1-py3-none-any.whl", hash = "sha256:1820fe14a9ab1107bfeff39259987429450b070ec0ff38cc87eb0d8c97fdc71a", size = 91191, upload-time = "2026-07-24T09:21:02.6Z" },
+]
+
+[[package]]
 name = "identify"
 version = "2.6.18"
 source = { registry = "https://pypi.org/simple" }
@@ -778,11 +808,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -1636,6 +1666,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8d/36/a566ba401ba9cbf5da74a7697e0ae3d1294a8ab7211bb1d7d18f0ce42b3f/starlette_admin-0.16.1.tar.gz", hash = "sha256:f34bdba033f0a2a4b39188e8e70a684956ef6b774db01762f44d022cde418b3a", size = 2104666, upload-time = "2026-06-06T20:10:40.307Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/7c/add7d4be6690fb61f4d30b672e544b1ac541c824f05a7de50ff5d8985db5/starlette_admin-0.16.1-py3-none-any.whl", hash = "sha256:a5e6cb0beb2e9bdc65b07dbb4bd01726aaad34764595e3bc3ff8578e698ff98a", size = 2176514, upload-time = "2026-06-06T20:10:42.308Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -50,6 +50,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
+    { name = "pytest-sugar" },
     { name = "respx" },
     { name = "ruff" },
 ]
@@ -83,6 +84,7 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = "~=1.2" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1.0" },
     { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.14.0" },
+    { name = "pytest-sugar", marker = "extra == 'dev'", specifier = ">=1.1.1" },
     { name = "respx", marker = "extra == 'dev'", specifier = ">=0.22.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4.4" },
     { name = "sqlmodel", specifier = ">=0.0.39" },
@@ -1313,6 +1315,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-sugar"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "termcolor" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0b/4e/60fed105549297ba1a700e1ea7b828044842ea27d72c898990510b79b0e2/pytest-sugar-1.1.1.tar.gz", hash = "sha256:73b8b65163ebf10f9f671efab9eed3d56f20d2ca68bda83fa64740a92c08f65d", size = 16533, upload-time = "2025-08-23T12:19:35.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/d5/81d38a91c1fdafb6711f053f5a9b92ff788013b19821257c2c38c1e132df/pytest_sugar-1.1.1-py3-none-any.whl", hash = "sha256:2f8319b907548d5b9d03a171515c1d43d2e38e32bd8182a1781eb20b43344cc8", size = 11440, upload-time = "2025-08-23T12:19:34.894Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -1666,6 +1681,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d3/1d/49347d67cf11a453d6f8379e0b87e6c1ecc671dee347f61de8240c5d2b11/starlette_admin-0.17.1.tar.gz", hash = "sha256:7bdeaf1c30fd9036ef3779fb0255002d3d18aaf6f7e674200e21c604ee563fc7", size = 2106865, upload-time = "2026-07-20T06:13:58.132Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fe/d1/5fc2df30b98b59cc81b8184b66ca5d76fe194a7a9ff5197b70a23e49fc0b/starlette_admin-0.17.1-py3-none-any.whl", hash = "sha256:685615945d55de636879e3523ec70a6419176f7cd6f04a17470e35670f96b972", size = 2183488, upload-time = "2026-07-20T06:13:56.048Z" },
+]
+
+[[package]]
+name = "termcolor"
+version = "3.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/79/cf31d7a93a8fdc6aa0fbb665be84426a8c5a557d9240b6239e9e11e35fc5/termcolor-3.3.0.tar.gz", hash = "sha256:348871ca648ec6a9a983a13ab626c0acce02f515b9e1983332b17af7979521c5", size = 14434, upload-time = "2025-12-29T12:55:21.882Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/d1/8bb87d21e9aeb323cc03034f5eaf2c8f69841e40e4853c2627edf8111ed3/termcolor-3.3.0-py3-none-any.whl", hash = "sha256:cf642efadaf0a8ebbbf4bc7a31cec2f9b5f21a9f726f4ccbb08192c9c26f43a5", size = 7734, upload-time = "2025-12-29T12:55:20.718Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

[AAI-871](https://biocloud.atlassian.net/browse/AAI-871): represent AAF users in the `aai-backend` database. After investigating how to do this, I've decided to use an `account_type` column on the existing `BiocommonsUser` model - makes it easier to enforce username/email uniqueness, and makes it easier to change between account types, which we want to support.

## Changes

- Add `account_type` column to `BiocommonsUser`, with `"auth0"` or `"aaf"` as values
- Database migration for `account_type` that autofills `auth0` for all existing users
- Add `account_type` to app metadata schema. Try to make sure we specify this explicitly wherever possible, but for now we also need a fallback to Auth0 as the default
- Update registration endpoint to set Auth0 as the account type (we will have a separate registration endpoint/flow for AAF)
- Add `account_actions` permissions so we can disable actions per account type
- Make user sync task only sync the DB connection for now - need to work out how to migrate/link AAF
  users before we sync them into the DB

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit / integration tests that prove my fix is effective or that my feature works
- [x] I have run all tests locally and they pass
- [x] I have updated the documentation (if applicable)
- [ ] For any new secrets, I have updated the [shared spreadsheet](https://docs.google.com/spreadsheets/d/16lGloFh4VxMmu6cJdeFVLy2654hdq-ZeErhB8UifSfI/edit?usp=sharing) and the [GitHub Secrets](https://github.com/AustralianBioCommons/aai-backend/settings/secrets/actions).

## How to Test Manually (if necessary)

Run `uv run pytest`


[AAI-871]: https://biocloud.atlassian.net/browse/AAI-871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ